### PR TITLE
fix(docker): correct postgres:18-alpine data directory mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       POSTGRES_PASSWORD: openwhistle
       POSTGRES_DB: openwhistle
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U openwhistle -d openwhistle"]
       interval: 10s


### PR DESCRIPTION
## Summary

- `postgres:18-alpine` changed the default `PGDATA` from `/var/lib/postgresql/data` to `/var/lib/postgresql`
- The named volume must be mounted at the parent path to avoid empty-directory failures at container startup

## Test plan

- [ ] Run `docker compose up` and verify the postgres container starts without errors
- [ ] Confirm data persists across container restarts

---
*Split from #29*