### PR TITLE
test(compat): fix UnicodeDecodeError on Windows in locale tests

### DIFF
--- a/tests/test_v040.py
+++ b/tests/test_v040.py
@@ -302,8 +302,8 @@ class TestI18n:
         import json
         from pathlib import Path
         locales = Path(__file__).parent.parent / "app" / "locales"
-        en = json.loads((locales / "en.json").read_text())
-        de = json.loads((locales / "de.json").read_text())
+        en = json.loads((locales / "en.json").read_text(encoding="utf-8"))
+        de = json.loads((locales / "de.json").read_text(encoding="utf-8"))
         missing = [k for k in en if k not in de]
         assert missing == [], f"Keys missing from de.json: {missing[:10]}"
 
@@ -311,8 +311,8 @@ class TestI18n:
         import json
         from pathlib import Path
         locales = Path(__file__).parent.parent / "app" / "locales"
-        en = json.loads((locales / "en.json").read_text())
-        fr = json.loads((locales / "fr.json").read_text())
+        en = json.loads((locales / "en.json").read_text(encoding="utf-8"))
+        fr = json.loads((locales / "fr.json").read_text(encoding="utf-8"))
         missing = [k for k in en if k not in fr]
         assert missing == [], f"Keys missing from fr.json: {missing[:10]}"
 


### PR DESCRIPTION
## Summary

- `read_text()` on Windows uses the system code page (cp1252) by default
- Locale JSON files contain accented characters that cp1252 cannot decode
- Adding explicit `encoding="utf-8"` to all `read_text()` calls in the test suite fixes the failure on Windows without affecting Linux/macOS

## Test plan

- [ ] Run `pytest tests/test_v040.py::TestI18n` on Windows — all locale completeness tests should pass
- [ ] Run the same tests on Linux — no regression

---
*Split from #29*