### PR TITLE
fix(security): add SECURE_COOKIES setting to decouple from DEMO_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ docker compose up -d
 # Open http://localhost:4009/setup to create the first admin account
 ```
 
+> **Accessing from other devices on the same network?**
+> Add `SECURE_COOKIES=false` to your `.env` (or `docker-compose.yml`) when the app is served over
+> plain HTTP. Browsers refuse to send `Secure` cookies over HTTP, causing session failures on
+> remote devices. Always keep `SECURE_COOKIES=true` (the default) behind HTTPS in production.
+
 For full installation instructions, environment variable reference, reverse proxy configuration,
 and administration guide, see **[openwhistle.net/docs.html](https://openwhistle.net/docs.html)**.
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -189,7 +189,7 @@ async def login_mfa_post(
         value=token,
         httponly=True,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
         max_age=settings.access_token_expire_minutes * 60,
     )
     return response
@@ -206,7 +206,7 @@ async def logout(
 
     response = RedirectResponse("/admin/login", status_code=302)
     response.delete_cookie(
-        "ow_session", httponly=True, samesite="lax", secure=not settings.demo_mode
+        "ow_session", httponly=True, samesite="lax", secure=settings.secure_cookies
     )
     return response
 
@@ -249,7 +249,7 @@ async def session_refresh(
         value=new_token,
         httponly=True,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
         max_age=settings.access_token_expire_minutes * 60,
     )
     return response
@@ -347,7 +347,7 @@ async def oidc_callback(
         value=token,
         httponly=True,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
         max_age=settings.access_token_expire_minutes * 60,
     )
     return response

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -95,13 +95,13 @@ def _set_submission_cookie(response: Response | RedirectResponse, session_id: st
         max_age=_SUBMISSION_TTL,
         httponly=True,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
     )
 
 
 def _clear_submission_cookie(response: Response | RedirectResponse) -> None:
     response.delete_cookie(
-        "ow-submission-session", httponly=True, samesite="lax", secure=not settings.demo_mode
+        "ow-submission-session", httponly=True, samesite="lax", secure=settings.secure_cookies
     )
 
 
@@ -137,7 +137,7 @@ async def set_language(
         max_age=31_536_000,
         httponly=False,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
     )
     return response
 
@@ -463,7 +463,7 @@ async def submit_post(
         )
         _clear_submission_cookie(response)
         response.delete_cookie(
-            "ow-status-session", httponly=True, samesite="lax", secure=not settings.demo_mode
+            "ow-status-session", httponly=True, samesite="lax", secure=settings.secure_cookies
         )
         return response
 
@@ -593,7 +593,7 @@ async def status_post(
         max_age=7200,
         httponly=True,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
     )
     return response
 
@@ -660,7 +660,7 @@ async def reply_post(
         max_age=7200,
         httponly=True,
         samesite="lax",
-        secure=not settings.demo_mode,
+        secure=settings.secure_cookies,
     )
     return response
 
@@ -676,7 +676,7 @@ async def status_logout(
         await redis.delete(f"status-session:{session_key}")
     response = RedirectResponse("/status", status_code=303)
     response.delete_cookie(
-        "ow-status-session", httponly=True, samesite="lax", secure=not settings.demo_mode
+        "ow-status-session", httponly=True, samesite="lax", secure=settings.secure_cookies
     )
     return response
 

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,10 @@ class Settings(BaseSettings):
     # Demo mode
     demo_mode: bool = False
 
+    # Cookie security — set to false when the app is served over plain HTTP
+    # (e.g. local network without TLS). Always keep true behind HTTPS.
+    secure_cookies: bool = True
+
     # Application
     app_name: str = "OpenWhistle"
     app_version: str = "1.1.0"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,6 +6,7 @@ services:
       REDIS_URL: "${REDIS_URL}"
       SECRET_KEY: "${SECRET_KEY}"
       DEMO_MODE: "${DEMO_MODE:-false}"
+      SECURE_COOKIES: "${SECURE_COOKIES:-true}"
       SUBMISSION_MODE_ENABLED: "${SUBMISSION_MODE_ENABLED:-true}"
       LOG_LEVEL: "${LOG_LEVEL:-INFO}"
       LOG_FORMAT: "${LOG_FORMAT:-json}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       REDIS_URL: "redis://redis:6379/0"
       SECRET_KEY: "change-me-in-production-use-a-long-random-string"
       DEMO_MODE: "false"
+      SECURE_COOKIES: "false"
     volumes:
       - ./app/static:/app/app/static
     depends_on:

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1062,6 +1062,12 @@
               <td><code>false</code></td>
             </tr>
             <tr>
+              <td><code class="env-key">SECURE_COOKIES</code></td>
+              <td><span class="env-required env-req-no">Optional</span></td>
+              <td>Set to <code>false</code> when the app is served over plain HTTP (e.g. local network without TLS). Must be <code>true</code> behind HTTPS. Browsers block <code>Secure</code> cookies over HTTP, causing session failures when accessed from other devices.</td>
+              <td><code>true</code></td>
+            </tr>
+            <tr>
               <td><code class="env-key">SUBMISSION_MODE_ENABLED</code></td>
               <td><span class="env-required env-req-no">Optional</span></td>
               <td>Set to <code>false</code> to hide the anonymous/confidential mode selection step from the submission wizard. When disabled, all reports are treated as anonymous.</td>


### PR DESCRIPTION
## Summary

- `DEMO_MODE=false` was hardcoding `secure=True` on cookies, breaking sessions over plain HTTP
- New `SECURE_COOKIES` env var (default: `true`) replaces all `secure=not settings.demo_mode` flags
- `SECURE_COOKIES=false` is pre-set in `docker-compose.yml` for local HTTP deployments
- Documented in `docker-compose.prod.yml`, `docs/docs.html`, and `README.md`

## Test plan

- [ ] Set `SECURE_COOKIES=false` in a local HTTP deployment — verify login session cookie is accepted
- [ ] Set `SECURE_COOKIES=true` (default) in an HTTPS deployment — verify cookie is still accepted
- [ ] Confirm `DEMO_MODE` no longer affects the cookie `secure` flag

> **Note:** This PR targets existing cookie-setting functions. After merging `feat/auth-totp-first-login`, the `mfa_setup_post` function will also need this flag — it is introduced already using `secure=not settings.demo_mode` and should be updated separately.

---
*Split from #29*