### PR TITLE
fix(ui): convert UTC timestamps to browser local timezone

### DIFF
--- a/app/templates/admin/audit_log.html
+++ b/app/templates/admin/audit_log.html
@@ -66,7 +66,7 @@
                     {% for entry in entries %}
                     <tr>
                         <td class="mono" style="font-size:0.78rem;white-space:nowrap;color:var(--text-muted);">
-                            {{ entry.created_at.strftime('%Y-%m-%d %H:%M UTC') }}
+                            <time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</time>
                         </td>
                         <td style="font-size:0.85rem;font-weight:600;">{{ entry.admin_username or '—' }}</td>
                         <td>

--- a/app/templates/admin/report.html
+++ b/app/templates/admin/report.html
@@ -60,7 +60,7 @@
                         <div class="message-meta">
                             <span class="message-meta-icon">{{ 'M' if msg.sender.value == 'admin' else 'W' }}</span>
                             {{ t('admin.sender.admin') if msg.sender.value == 'admin' else t('admin.whistleblower') }}
-                            &middot; <span class="mono">{{ msg.sent_at.strftime('%Y-%m-%d %H:%M UTC') }}</span>
+                            &middot; <span class="mono"><time data-utc="{{ msg.sent_at.isoformat() }}">{{ msg.sent_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                         </div>
                         <div class="message-content">{{ decrypted_messages[loop.index0] if decrypted_messages and loop.index0 < decrypted_messages|length else msg.content }}</div>
                     </div>
@@ -103,7 +103,7 @@
                     <div style="border-left:3px solid var(--warning);padding:0.6rem 0.75rem;background:var(--warning-subtle);border-radius:0 4px 4px 0;">
                         <div style="font-size:0.75rem;color:var(--text-muted);margin-bottom:0.25rem;">
                             <strong style="color:var(--text-secondary);">{{ note.author_username }}</strong>
-                            &middot; <span class="mono">{{ note.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</span>
+                            &middot; <span class="mono"><time data-utc="{{ note.created_at.isoformat() }}">{{ note.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                         </div>
                         <div style="font-size:0.88rem;white-space:pre-wrap;color:var(--text-secondary);">{{ note.content }}</div>
                     </div>
@@ -168,7 +168,7 @@
                 <div style="display:flex;flex-direction:column;gap:0.4rem;">
                     {% for entry in audit_entries %}
                     <div style="display:flex;gap:0.75rem;align-items:baseline;padding:0.35rem 0;border-bottom:1px solid var(--border);font-size:0.8rem;">
-                        <span class="mono" style="color:var(--text-muted);white-space:nowrap;flex-shrink:0;">{{ entry.created_at.strftime('%m-%d %H:%M') }}</span>
+                        <span class="mono" style="color:var(--text-muted);white-space:nowrap;flex-shrink:0;"><time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%m-%d %H:%M') }}</time></span>
                         <span style="color:var(--text-secondary);font-weight:600;flex-shrink:0;">{{ entry.admin_username or '—' }}</span>
                         <span style="color:var(--accent);font-family:var(--font-mono);font-size:0.75rem;">{{ entry.action }}</span>
                         {% if entry.detail %}
@@ -197,7 +197,7 @@
                 <div style="display:flex;flex-direction:column;gap:1rem;font-size:0.875rem;">
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.submitted') }}</div>
-                        <span class="mono" style="font-size:0.82rem;">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</span>
+                        <span class="mono" style="font-size:0.82rem;"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                     </div>
 
                     <div>
@@ -364,7 +364,7 @@
                     <div class="alert alert-error" style="margin-bottom:1rem;">
                         <div class="alert-title">{{ t('admin.report.delete.pending.title') }}</div>
                         {{ t('admin.report.delete.pending.body', username=report.deletion_request.requested_by_username) }}
-                        <div class="mono" style="font-size:0.75rem;margin-top:0.4rem;">{{ report.deletion_request.requested_at.strftime('%Y-%m-%d %H:%M UTC') }}</div>
+                        <div class="mono" style="font-size:0.75rem;margin-top:0.4rem;"><time data-utc="{{ report.deletion_request.requested_at.isoformat() }}">{{ report.deletion_request.requested_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></div>
                     </div>
 
                     {% if report.deletion_request.requested_by_id == user.id %}

--- a/app/templates/admin/retention.html
+++ b/app/templates/admin/retention.html
@@ -47,7 +47,7 @@
             <div class="stat-card__label">Next Scheduled Run</div>
             <div class="stat-card__value">
                 {% if retention_enabled %}
-                    {{ next_run.strftime('%Y-%m-%d 03:00 UTC') }}
+                    <time data-utc="{{ next_run.isoformat() }}">{{ next_run.strftime('%Y-%m-%d 03:00 UTC') }}</time>
                 {% else %}
                     —
                 {% endif %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -148,6 +148,29 @@
 
     <script src="/static/js/site.js"></script>
     <script>
+    (function() {
+        function pad(n) { return n < 10 ? '0' + n : '' + n; }
+        function tzLabel(d) {
+            try {
+                var parts = Intl.DateTimeFormat(undefined, {timeZoneName: 'short'}).formatToParts(d);
+                var t = parts.find(function(p) { return p.type === 'timeZoneName'; });
+                return t ? t.value : '';
+            } catch(e) { return ''; }
+        }
+        document.querySelectorAll('time[data-utc]').forEach(function(el) {
+            try {
+                var d = new Date(el.getAttribute('data-utc'));
+                if (isNaN(d)) return;
+                var tz = tzLabel(d);
+                el.textContent = d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
+                                 ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes()) +
+                                 (tz ? ' ' + tz : '');
+                el.title = 'UTC: ' + el.getAttribute('data-utc').slice(0, 16).replace('T', ' ');
+            } catch(e) {}
+        });
+    })();
+    </script>
+    <script>
     // Language picker dropdown
     (function() {
         var btn = document.getElementById('lang-picker-btn');

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -140,12 +140,12 @@
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;font-size:0.85rem;color:var(--text-muted);">
             <div>
                 <div class="detail-label">{{ t('status.meta.submitted') }}</div>
-                <span class="mono" style="color:var(--text-primary);">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</span>
+                <span class="mono" style="color:var(--text-primary);"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
             </div>
             {% if report.acknowledged_at %}
             <div>
                 <div class="detail-label">{{ t('status.meta.acknowledged') }}</div>
-                <span class="mono" style="color:var(--text-primary);">{{ report.acknowledged_at.strftime('%Y-%m-%d %H:%M UTC') }}</span>
+                <span class="mono" style="color:var(--text-primary);"><time data-utc="{{ report.acknowledged_at.isoformat() }}">{{ report.acknowledged_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
             </div>
             {% endif %}
             {% if report.feedback_due_at %}
@@ -250,7 +250,7 @@
                 <div class="message-meta">
                     <span class="message-meta-icon">{{ 'M' if msg.sender.value == 'admin' else 'W' }}</span>
                     {{ t('status.sender.admin') if msg.sender.value == 'admin' else t('status.sender.user') }}
-                    &middot; {{ msg.sent_at.strftime('%Y-%m-%d %H:%M UTC') }}
+                    &middot; <time data-utc="{{ msg.sent_at.isoformat() }}">{{ msg.sent_at.strftime('%Y-%m-%d %H:%M UTC') }}</time>
                 </div>
                 <div class="message-content">{{ decrypted_messages[loop.index0] if decrypted_messages and loop.index0 < decrypted_messages|length else msg.content }}</div>
             </div>


### PR DESCRIPTION
## Summary

- Wraps all datetime displays (fields with HH:MM) in `<time data-utc="...">` elements across templates
- Adds a small inline script to `base.html` that converts each element to the visitor's local timezone using the browser's `Intl.DateTimeFormat` API
- Displays the timezone abbreviation alongside the time (e.g. `14:00 BRT`, `02:00 JST`, `19:00 CEST`)
- Hovering over any converted timestamp shows the original UTC value via `title` attribute
- Graceful fallback: if JS is disabled, the original UTC text remains visible
- Date-only fields (legal HinSchG deadlines like `feedback_due_at`) are intentionally left unchanged — converting those could shift the day and be misleading

## Affected templates

- `app/templates/base.html` — conversion script
- `app/templates/status.html` — submitted at, acknowledged at, message timestamps
- `app/templates/admin/report.html` — submitted at, messages, internal notes, audit timeline, deletion request
- `app/templates/admin/audit_log.html` — audit entry timestamps
- `app/templates/admin/retention.html` — next scheduled run

## Test plan

- [x] Open the whistleblower status page with a report and verify timestamps show local time with TZ abbreviation
- [x] Open an admin report and verify all datetime fields convert correctly
- [x] Check the audit log page for converted timestamps
- [x] Hover over a timestamp and confirm the UTC tooltip appears
- [x] Disable JS in browser and confirm UTC fallback text is shown
- [x] Test from a non-UTC browser timezone (e.g. change OS timezone to JST or BRT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)