### PR TITLE
fix(security): resolve reported advisories + bump dependencies (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,100 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.1] — 2026-07-13
+
+Security release: four privately-reported advisories plus an internal
+adversarial "bug-bounty" audit that fixed ~25 further edge-case defects. All
+users of 1.1.0 should upgrade.
+
+### Breaking
+
+- **`SECRET_KEY` must now be at least 32 characters.** The application refuses
+  to start with a shorter key. `SECRET_KEY` is the root secret for admin
+  authentication and for encrypting confidential whistleblower identities, so a
+  weak key undermines the platform's core protection. Generate a strong one
+  with `python -c 'import secrets; print(secrets.token_urlsafe(48))'`. Note:
+  rotating `SECRET_KEY` makes previously-encrypted confidential fields
+  unreadable — set a strong key from the start.
+
+### Security
+
+- **Report deanonymization / IDOR** (GHSA-q3v3-5xf4-xjqr, High): every
+  `/admin/reports/{id}*` endpoint now enforces object-level authorization. Case
+  managers can only access reports assigned to them; admins are scoped to their
+  own organisation (superadmins span all) when multi-tenancy is enabled. The
+  dashboard list and the confidential-identity block are scoped the same way, so
+  an unassigned case manager can no longer read a confidential whistleblower's
+  identity.
+- **Privilege escalation** (GHSA-g3xj-3929-r45h, High): the role-assignment
+  endpoints now enforce privilege tiers. Only a superadmin may grant or modify
+  the superadmin role, an account can no longer change its own role, and the last
+  active administrator can no longer be demoted away.
+- **Stored XSS** (GHSA-24hg-pf84-jj7x, High): admin usernames and organisation
+  names are no longer interpolated into inline `onclick` handlers; confirmation
+  prompts moved to a safe `data-confirm` attribute. Locally-created usernames are
+  validated against a strict allowlist.
+- **Weak / duplicated HTTP security headers** (GHSA-gh23-4h5j-cqj8, Medium):
+  security headers are now emitted by a single authoritative layer (the
+  application middleware); the bundled nginx template no longer re-emits them,
+  removing the duplicated/conflicting `Strict-Transport-Security`,
+  `X-Content-Type-Options` and `X-Frame-Options` headers. The Content-Security-
+  Policy no longer uses `'unsafe-inline'`: it is now a strict, per-response
+  nonce-based policy for both scripts and styles.
+
+### Fixed (internal bug-bounty audit)
+
+Real defects found by an adversarial audit, each covered by a regression test
+in `tests/test_bug_bounty_v111.py`:
+
+- **Retention could delete reopened cases early**: `closed_at` was never
+  refreshed when a case was reopened and re-closed, so the auto-deletion job
+  could remove reports far before the statutory retention period had elapsed
+  since their actual closure. It is now cleared on reopen and re-stamped on
+  re-close.
+- **Superadmin lockout**: a plain admin could deactivate a superadmin, and the
+  last active privileged account could be deactivated/demoted, leaving no one
+  able to administer the instance. Both are now blocked.
+- **Attachment downloads with non-Latin-1 filenames** (CJK, Cyrillic, emoji)
+  raised `UnicodeEncodeError` and 500'd — the evidence became permanently
+  undownloadable. `Content-Disposition` now uses RFC 5987 encoding. PDF export
+  no longer crashes on non-Latin-1 note authors either.
+- **MFA brute-force**: TOTP guessing is now rate-limited, and a valid code is
+  one-time-use within its window (blocks AiTM replay into a second session).
+- **`acknowledge` is now idempotent** so the statutory feedback deadline cannot
+  be pushed out by re-invoking it.
+- **Concurrent submissions** no longer 500 on a case-number collision (retry).
+- Reports can no longer be assigned to a deactivated user (orphaned cases).
+- Linked-report metadata is filtered through the object-level authz check.
+- SLA reminder de-duplication now covers the full warn window (was re-firing
+  every ~hour for days); per-report failures are isolated.
+- `SUBMISSION_MODE_ENABLED=false` now actually forces anonymous submissions,
+  and confidential PII is purged from the session when switching to anonymous.
+- The whistleblower PIN lockout is keyed on the case number, so it can no longer
+  be bypassed by fetching a fresh anonymous session token before each guess.
+- Login now runs a constant dummy password hash for unknown users (removes a
+  username-enumeration timing side-channel).
+- Background scheduler jobs take a Redis lock so a scaled/stateless deployment
+  does not run them once per replica (duplicate audit entries / notifications).
+- 4-eyes delete confirmation re-checks the request under a row lock, so a
+  concurrent cancel cannot be raced into deleting a withdrawn report.
+- The submission wizard rejects out-of-order steps (blocks jumping straight to
+  the attachment step to stash blobs in Redis) and no longer adopts a
+  client-supplied session id with no server-side state (session fixation).
+- Case-insensitive duplicate-username check; empty decrypted bodies no longer
+  fall back to raw ciphertext; oversized uploads are rejected without buffering
+  the whole body; relinking already-linked cases returns 409 instead of 500;
+  decryption failures are logged rather than silently shown as blank.
+
+Remaining lower-severity findings are tracked in GitHub issues #42–#46.
+
+### Changed
+
+- All Python dependency floors raised to their current major versions (notably
+  redis 8, bcrypt 5, SQLAlchemy 2.0.51, uvicorn 0.51, FastAPI 0.139, mypy 2,
+  pytest 9, pytest-asyncio 1.x). GitHub Actions `actions/checkout` and
+  `codecov/codecov-action` bumped to v7.
+
 ## [1.1.0] — 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue?logo=gnu)](LICENSE)
 [![Version](https://img.shields.io/github/v/release/openwhistle/OpenWhistle?logo=github)](https://github.com/openwhistle/OpenWhistle/releases)
 [![Python](https://img.shields.io/badge/python-3.14-blue?logo=python&logoColor=white)](https://python.org)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.136-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.139-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![PostgreSQL](https://img.shields.io/badge/postgresql-18-336791?logo=postgresql&logoColor=white)](https://postgresql.org)
 [![Redis](https://img.shields.io/badge/redis-8-DC382D?logo=redis&logoColor=white)](https://redis.io)
 [![Docker Pulls](https://img.shields.io/docker/pulls/kermit1337/openwhistle?logo=docker)](https://hub.docker.com/r/kermit1337/openwhistle)
@@ -67,6 +67,13 @@ zero vendor lock-in, and privacy-first by design.
 - **Dashboard statistics** — SLA compliance rate, status distribution, category breakdown.
 - **Mandatory MFA** — TOTP (compatible with any authenticator app) required for every admin account.
   No exceptions, no bypass.
+- **Object-level authorization** — Every report endpoint enforces per-record access: case managers
+  see only their assigned reports, admins are scoped to their organisation. Role assignment enforces
+  privilege tiers (only superadmins grant superadmin; no self-role-change; the last admin cannot be
+  demoted away).
+- **Hardened HTTP security** — Strict, per-response nonce-based Content-Security-Policy (no
+  `unsafe-inline`), consolidated single-source security headers (HSTS, `X-Frame-Options`, nosniff),
+  and strict username validation.
 - **OIDC / SSO support** — Optional single sign-on via any OpenID Connect provider (Keycloak,
   Authentik, Azure AD, Google, …).
 - **File attachments** — Whistleblowers can attach evidence files (PDF, images, Word, Excel, CSV,

--- a/ansible/roles/openwhistle/templates/nginx.conf.j2
+++ b/ansible/roles/openwhistle/templates/nginx.conf.j2
@@ -39,10 +39,12 @@ http {
         ssl_session_cache shared:SSL:10m;
         ssl_session_timeout 1d;
 
-        add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-        add_header X-Content-Type-Options nosniff always;
-        add_header X-Frame-Options SAMEORIGIN always;
-        add_header Referrer-Policy no-referrer always;
+        # Security headers (HSTS, X-Content-Type-Options, X-Frame-Options,
+        # Referrer-Policy, CSP, …) are emitted by a single authoritative layer:
+        # the application's SecurityMiddleware (app/middleware.py). They are
+        # intentionally NOT set here — nginx `add_header` appends rather than
+        # replaces upstream headers, so duplicating them produced conflicting,
+        # unrecognised headers (GHSA-gh23-4h5j-cqj8).
 
         # Strip ALL IP-forwarding headers for whistleblower anonymity
         proxy_set_header X-Forwarded-For     "";

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -13,7 +13,7 @@ from app.config import settings
 from app.csrf import validate_csrf
 from app.database import get_db
 from app.middleware import check_ip_warning, clear_ip_warning
-from app.models.report import STATUS_TRANSITIONS, ReportStatus
+from app.models.report import STATUS_TRANSITIONS, Report, ReportStatus
 from app.models.user import AdminRole, AdminUser
 from app.redis_client import get_redis
 from app.services import audit as audit_service
@@ -44,6 +44,49 @@ async def _cleanup_report_sessions(redis: Redis, report_id: uuid.UUID) -> None:
 
 _ALLOWED_SORT = frozenset({"submitted_at", "case_number", "category", "status"})
 _ALLOWED_PER_PAGE = frozenset({10, 25, 50, 100})
+
+# Role privilege ranking — used for tier checks in user management.
+_ROLE_RANK: dict[AdminRole, int] = {
+    AdminRole.case_manager: 0,
+    AdminRole.admin: 1,
+    AdminRole.superadmin: 2,
+}
+
+
+def _can_access_report(user: AdminUser, report: Report) -> bool:
+    """Object-level authorization for a single report.
+
+    - superadmin: every report.
+    - admin: every report in their own organisation (all reports when
+      multi-tenancy is disabled or the report has no org).
+    - case_manager: only reports assigned to them (and, with multi-tenancy,
+      within their own organisation).
+    """
+    if user.role == AdminRole.superadmin:
+        return True
+    if (
+        settings.multi_tenancy_enabled
+        and report.org_id is not None
+        and user.org_id != report.org_id
+    ):
+        return False
+    if user.role == AdminRole.case_manager:
+        return report.assigned_to_id == user.id
+    return True
+
+
+async def _get_authorized_report(
+    db: AsyncSession, report_id: uuid.UUID, user: AdminUser
+) -> Report:
+    """Fetch a report and enforce object-level authorization.
+
+    Returns 404 (never 403) on both missing and unauthorized reports so that
+    the existence of a report is not leaked across the authorization boundary.
+    """
+    report = await report_service.get_report_by_id(db, report_id)
+    if not report or not _can_access_report(user, report):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return report
 
 
 # ── Dashboard ──────────────────────────────────────────────────────
@@ -87,7 +130,18 @@ async def dashboard(
     sort_by: SortField = raw_sort if raw_sort in _ALLOWED_SORT else "submitted_at"  # type: ignore[assignment]
     sort_dir: SortDir = "asc" if raw_dir == "asc" else "desc"
 
-    assigned_filter = current_user.id if my_cases else None
+    # Object-level scoping: case managers only ever see reports assigned to
+    # them; multi-tenant admins are confined to their own organisation
+    # (superadmins span all organisations).
+    if current_user.role == AdminRole.case_manager:
+        assigned_filter: uuid.UUID | None = current_user.id
+    else:
+        assigned_filter = current_user.id if my_cases else None
+    org_filter = (
+        current_user.org_id
+        if settings.multi_tenancy_enabled and current_user.role != AdminRole.superadmin
+        else None
+    )
     reports, total = await report_service.get_reports_paginated(
         db,
         page=page,
@@ -97,6 +151,7 @@ async def dashboard(
         sort_dir=sort_dir,
         assigned_to_id=assigned_filter,
         location_id=location_filter,
+        org_id=org_filter,
     )
     stats = await report_service.get_report_stats(db)
     total_pages = max(1, (total + per_page - 1) // per_page)
@@ -148,9 +203,7 @@ async def report_detail(
 
     from app.services.users import get_all_users
 
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     all_admins = await get_all_users(db)
 
@@ -362,12 +415,10 @@ async def link_report(
     current_user: AdminUser = Depends(get_current_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=404)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     other = await report_service.get_report_by_case_number(db, case_number.strip().upper())
-    if not other:
+    if not other or not _can_access_report(current_user, other):
         raise HTTPException(status_code=404, detail="Case number not found")
     if other.id == report.id:
         raise HTTPException(status_code=400, detail="Cannot link a report to itself")
@@ -390,9 +441,7 @@ async def unlink_report(
     current_user: AdminUser = Depends(get_current_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=404)
+    report = await _get_authorized_report(db, report_id, current_user)
     link = await report_service.get_link(db, link_id)
     if not link:
         raise HTTPException(status_code=404)
@@ -420,9 +469,7 @@ async def request_delete(
     current_user: AdminUser = Depends(require_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=404)
+    report = await _get_authorized_report(db, report_id, current_user)
     if report.deletion_request is not None:
         raise HTTPException(status_code=409, detail="A deletion request already exists.")
 
@@ -443,9 +490,7 @@ async def confirm_delete(
     current_user: AdminUser = Depends(require_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=404)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     dr = report.deletion_request
     if not dr:
@@ -471,9 +516,7 @@ async def cancel_delete(
     current_user: AdminUser = Depends(require_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=404)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     dr = report.deletion_request
     if not dr:
@@ -501,9 +544,7 @@ async def export_pdf(
 ) -> Response:
     from app.services.pdf import generate_report_pdf
 
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=404)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     pdf_bytes = generate_report_pdf(report)
     safe_name = f"{report.case_number}_export.pdf"
@@ -525,6 +566,10 @@ async def admin_download_attachment(
     current_user: AdminUser = Depends(get_current_admin),
 ) -> Response:
     from app.services.attachment import get_attachment_by_id
+
+    # Enforce object-level authorization on the parent report before serving
+    # any attachment bytes (prevents cross-assignment / cross-org access).
+    await _get_authorized_report(db, report_id, current_user)
 
     attachment = await get_attachment_by_id(db, attachment_id)
     if not attachment or attachment.report_id != report_id:
@@ -677,7 +722,17 @@ async def create_user(
     except ValueError:
         role_enum = AdminRole.admin
 
-    new_user, _totp_secret = await svc_create(db, username.strip(), password, role_enum)
+    # Privilege-tier check: only a superadmin may create superadmin accounts.
+    if role_enum == AdminRole.superadmin and current_user.role != AdminRole.superadmin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only a superadmin can create superadmin accounts.",
+        )
+
+    try:
+        new_user, _totp_secret = await svc_create(db, username.strip(), password, role_enum)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     await audit_service.log(
         db, current_user, AuditAction.ADMIN_CREATED,
         detail={"username": new_user.username, "role": role_enum.value},
@@ -704,6 +759,23 @@ async def change_user_role(
         role_enum = AdminRole(role)
     except ValueError as exc:
         raise HTTPException(status_code=400) from exc
+
+    # Prevent self-escalation: an account may not change its own role.
+    if target.id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot change your own role.",
+        )
+    # Privilege-tier check: only a superadmin may grant the superadmin role or
+    # modify an existing superadmin (an admin cannot promote itself/others to,
+    # or demote, the top tier).
+    if (
+        role_enum == AdminRole.superadmin or target.role == AdminRole.superadmin
+    ) and current_user.role != AdminRole.superadmin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only a superadmin can assign or change the superadmin role.",
+        )
 
     old_role = target.role.value
     await update_user_role(db, target, role_enum)

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -211,7 +211,10 @@ async def report_detail(
     linked: list[dict[str, str]] = []
     for linked_report_id, link_id in report_service.get_linked_reports(report):
         linked_report = await report_service.get_report_by_id(db, linked_report_id)
-        if linked_report:
+        # Only reveal a linked report's metadata to a viewer who is independently
+        # authorized to see it — a link must not leak case data across the
+        # assignment / organisation boundary.
+        if linked_report and _can_access_report(current_user, linked_report):
             linked.append({
                 "link_id": link_id,
                 "case_number": linked_report.case_number,
@@ -358,6 +361,11 @@ async def assign_report(
         assignee = await get_admin_by_id(db, aid)
         if not assignee:
             raise HTTPException(status_code=404, detail="Admin user not found")
+        if not assignee.is_active:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot assign a report to a deactivated user.",
+            )
 
     old_assignee = report.assigned_to.username if report.assigned_to else None
     await report_service.assign_report(db, report, assignee)
@@ -412,6 +420,8 @@ async def link_report(
         raise HTTPException(status_code=404, detail="Case number not found")
     if other.id == report.id:
         raise HTTPException(status_code=400, detail="Cannot link a report to itself")
+    if await report_service.get_link_between(db, report.id, other.id) is not None:
+        raise HTTPException(status_code=409, detail="These cases are already linked.")
 
     await report_service.link_cases(db, report, other, current_user)
     await audit_service.log(
@@ -573,11 +583,11 @@ async def admin_download_attachment(
             raise HTTPException(status_code=404)
         data = attachment.data
 
-    safe_name = attachment.filename.replace('"', "")
+    from app.services.attachment import content_disposition_attachment
     return Response(
         content=data,
         media_type=attachment.content_type,
-        headers={"Content-Disposition": f'attachment; filename="{safe_name}"'},
+        headers={"Content-Disposition": content_disposition_attachment(attachment.filename)},
     )
 
 
@@ -700,10 +710,10 @@ async def create_user(
     current_user: AdminUser = Depends(require_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    from app.services import auth as auth_svc
     from app.services.users import create_user as svc_create
+    from app.services.users import get_user_by_username_ci
 
-    existing = await auth_svc.get_user_by_username(db, username.strip())
+    existing = await get_user_by_username_ci(db, username.strip())
     if existing:
         raise HTTPException(status_code=409, detail="Username already exists")
 
@@ -801,7 +811,7 @@ async def deactivate_user(
     current_user: AdminUser = Depends(require_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    from app.services.users import count_active_admins, get_user_by_id
+    from app.services.users import count_active_privileged_admins, get_user_by_id
     from app.services.users import deactivate_user as svc_deact
 
     target = await get_user_by_id(db, user_id)
@@ -810,13 +820,24 @@ async def deactivate_user(
     if target.id == current_user.id:
         raise HTTPException(status_code=400, detail="You cannot deactivate your own account.")
 
-    if target.role == AdminRole.admin:
-        active_admin_count = await count_active_admins(db)
-        if active_admin_count <= 1:
-            raise HTTPException(
-                status_code=422,
-                detail="Cannot deactivate the last active admin.",
-            )
+    # Only a superadmin may deactivate a superadmin (a plain admin cannot disable
+    # a higher-privileged account).
+    if target.role == AdminRole.superadmin and current_user.role != AdminRole.superadmin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only a superadmin can deactivate a superadmin account.",
+        )
+
+    # Availability invariant: never deactivate the last account able to
+    # administer the instance (admin OR superadmin).
+    if (
+        target.role in (AdminRole.admin, AdminRole.superadmin)
+        and await count_active_privileged_admins(db) <= 1
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot deactivate the last active administrator.",
+        )
 
     await svc_deact(db, target)
     await audit_service.log(

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -750,7 +750,11 @@ async def change_user_role(
     current_user: AdminUser = Depends(require_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    from app.services.users import get_user_by_id, update_user_role
+    from app.services.users import (
+        count_active_privileged_admins,
+        get_user_by_id,
+        update_user_role,
+    )
 
     target = await get_user_by_id(db, user_id)
     if not target:
@@ -775,6 +779,18 @@ async def change_user_role(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only a superadmin can assign or change the superadmin role.",
+        )
+    # Availability invariant: never demote the last privileged account, or the
+    # instance would be left with no admin/superadmin able to manage it.
+    if (
+        target.role in (AdminRole.admin, AdminRole.superadmin)
+        and role_enum not in (AdminRole.admin, AdminRole.superadmin)
+        and target.is_active
+        and await count_active_privileged_admins(db) <= 1
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Cannot demote the last active administrator.",
         )
 
     old_role = target.role.value

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -269,9 +269,7 @@ async def acknowledge_report(
     current_user: AdminUser = Depends(get_current_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     old_status = report.status.value
     await report_service.acknowledge_report(db, report)
@@ -292,9 +290,7 @@ async def update_status(
     current_user: AdminUser = Depends(get_current_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     try:
         s = ReportStatus(new_status)
@@ -326,9 +322,7 @@ async def admin_reply(
     current_user: AdminUser = Depends(get_current_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    report = await _get_authorized_report(db, report_id, current_user)
     if not content.strip():
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
@@ -353,9 +347,7 @@ async def assign_report(
 ) -> RedirectResponse:
     from app.services.users import get_user_by_id as get_admin_by_id
 
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    report = await _get_authorized_report(db, report_id, current_user)
 
     assignee: AdminUser | None = None
     if admin_id:
@@ -389,9 +381,7 @@ async def add_note(
     current_user: AdminUser = Depends(get_current_admin),
     _csrf: None = Depends(validate_csrf),
 ) -> RedirectResponse:
-    report = await report_service.get_report_by_id(db, report_id)
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    report = await _get_authorized_report(db, report_id, current_user)
     if not content.strip():
         raise HTTPException(status_code=422)
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -137,11 +137,11 @@ async def dashboard(
         assigned_filter: uuid.UUID | None = current_user.id
     else:
         assigned_filter = current_user.id if my_cases else None
-    org_filter = (
-        current_user.org_id
-        if settings.multi_tenancy_enabled and current_user.role != AdminRole.superadmin
-        else None
-    )
+    # Scope the list to the caller's organisation for multi-tenant non-superadmins.
+    # This must apply even when their org_id is None, otherwise an org-less admin
+    # would fall through to the unfiltered "see everything" branch — a metadata
+    # leak inconsistent with the object-level check that denies them those reports.
+    scope_org = settings.multi_tenancy_enabled and current_user.role != AdminRole.superadmin
     reports, total = await report_service.get_reports_paginated(
         db,
         page=page,
@@ -151,7 +151,8 @@ async def dashboard(
         sort_dir=sort_dir,
         assigned_to_id=assigned_filter,
         location_id=location_filter,
-        org_id=org_filter,
+        org_id=current_user.org_id if scope_org else None,
+        scope_org=scope_org,
     )
     stats = await report_service.get_report_stats(db)
     total_pages = max(1, (total + per_page - 1) // per_page)

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -493,7 +493,9 @@ async def confirm_delete(
 ) -> RedirectResponse:
     report = await _get_authorized_report(db, report_id, current_user)
 
-    dr = report.deletion_request
+    # Re-read the deletion request under a row lock so a concurrent cancel
+    # cannot withdraw it between this check and the actual deletion.
+    dr = await report_service.get_active_deletion_request(db, report.id, for_update=True)
     if not dr:
         raise HTTPException(status_code=400, detail="No pending deletion request.")
     if dr.requested_by_id == current_user.id:

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -24,6 +24,10 @@ from app.templating import render
 
 router = APIRouter(prefix="/admin")
 
+# Precomputed bcrypt hash used only to equalize login timing when no real hash
+# is available (missing user / SSO-only account). Never matches a user password.
+_TIMING_DUMMY_HASH = auth_service.hash_password("timing-equalizer-not-a-real-secret")
+
 
 @router.get("", response_class=HTMLResponse, include_in_schema=False)
 @router.get("/", response_class=HTMLResponse, include_in_schema=False)
@@ -116,9 +120,14 @@ async def login_post(
     # ── Local password authentication path ─────────────────────────
     user = await auth_service.get_user_by_username(db, username)
 
-    pw_ok = user is not None and user.password_hash and auth_service.verify_password(
-        password, user.password_hash
-    )
+    if user is not None and user.password_hash:
+        pw_ok = auth_service.verify_password(password, user.password_hash)
+    else:
+        # Constant-time-ish: run a dummy bcrypt check so a nonexistent username
+        # or an SSO/LDAP-only account (no local hash) is not distinguishable by
+        # response latency (username enumeration side-channel).
+        auth_service.verify_password(password, _TIMING_DUMMY_HASH)
+        pw_ok = False
     if not pw_ok:
         await rl.record_admin_login_failure(redis, username)
         return render(request, "login.html", _login_ctx({
@@ -180,6 +189,15 @@ async def login_mfa_post(
     code_valid = (settings.demo_mode and verify_demo_totp(totp_code)) or verify_totp(
         user.totp_secret, totp_code
     )
+
+    # One-time use: a valid code may authenticate exactly one session within its
+    # ~90s validity window. Prevents an intercepted/relayed code from logging in
+    # a second, attacker-controlled session (AiTM replay). Skipped in demo mode
+    # where the static code is intentionally reusable.
+    if code_valid and not settings.demo_mode:
+        used_key = f"openwhistle:totp_used:{user.id}:{totp_code}"
+        if not await redis.set(used_key, "1", nx=True, ex=90):
+            code_valid = False
 
     if not code_valid:
         await rl.record_admin_login_failure(redis, user.username)

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -163,11 +163,26 @@ async def login_mfa_post(
     if not user:
         return RedirectResponse("/admin/login", status_code=302)
 
+    # Second-factor guessing must be throttled just like the password factor,
+    # otherwise an attacker who already holds the password can brute-force the
+    # 6-digit TOTP unhindered.
+    if not await rl.check_admin_login_attempts(redis, user.username):
+        return render(
+            request,
+            "login_mfa.html",
+            {
+                "error": "Account temporarily locked due to too many attempts.",
+                "is_demo": settings.demo_mode,
+            },
+            status_code=429,
+        )
+
     code_valid = (settings.demo_mode and verify_demo_totp(totp_code)) or verify_totp(
         user.totp_secret, totp_code
     )
 
     if not code_valid:
+        await rl.record_admin_login_failure(redis, user.username)
         new_temp = secrets.token_urlsafe(32)
         await auth_service.store_totp_pending(redis, new_temp, user_id)
         return render(

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -4,6 +4,7 @@ import json
 import re
 import secrets
 import uuid
+from collections.abc import Awaitable
 from typing import Any, cast
 from urllib.parse import urlsplit
 
@@ -164,7 +165,9 @@ async def health(
         healthy = False
 
     try:
-        await redis.ping()
+        # redis-py 8's async stubs type ping() as Awaitable[bool] | bool; the
+        # async client always returns an awaitable here.
+        await cast("Awaitable[Any]", redis.ping())
         components["redis"] = "ok"
     except Exception:
         components["redis"] = "error"

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -263,6 +263,12 @@ async def submit_post(
         else secrets.token_urlsafe(32)
     )
     state = await _load_submission(redis, session_id)
+    if not state and raw_cookie:
+        # Never adopt a client-supplied session id that has no server-side state
+        # (session fixation): mint a fresh server-generated id instead, matching
+        # the GET handler's behaviour.
+        session_id = secrets.token_urlsafe(32)
+        state = {}
 
     locations = await get_active_locations(db)
     has_locations = len(locations) > 0
@@ -285,6 +291,14 @@ async def submit_post(
         resp = render(request, "submit.html", ctx)
         _set_submission_cookie(resp, session_id)
         return resp
+
+    # Reject a step that runs ahead of the session's progress. Without this an
+    # unauthenticated client could POST step=<attachments> on a brand-new
+    # session and stash multi-MB blobs in Redis, bypassing the wizard entirely.
+    if action == "next" and step > state.get("step", _STEP_MODE):
+        state.setdefault("step", _STEP_MODE)
+        await _save_submission(redis, session_id, state)
+        return _render_step({"error": "session_incomplete"})
 
     if action == "back":
         current = state.get("step", _STEP_MODE)

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -297,20 +297,33 @@ async def submit_post(
 
     # ── Step 1: mode selection ─────────────────────────────────────
     if step == _STEP_MODE:
-        if submission_mode not in ("anonymous", "confidential"):
+        # When the operator has disabled mode selection, every report is forced
+        # to anonymous — a confidential submission must not be accepted.
+        effective_mode = submission_mode
+        if not settings.submission_mode_enabled:
+            effective_mode = "anonymous"
+
+        if effective_mode not in ("anonymous", "confidential"):
             state["step"] = _STEP_MODE
             await _save_submission(redis, session_id, state)
             return _render_step({"error": "mode_required"})
 
-        state["submission_mode"] = submission_mode
+        state["submission_mode"] = effective_mode
 
-        if submission_mode == "confidential":
+        if effective_mode == "confidential":
             name_stripped = confidential_name.strip()
             contact_stripped = confidential_contact.strip()
             email_stripped = secure_email.strip()
             state["confidential_name"] = name_stripped
             state["confidential_contact"] = contact_stripped
             state["secure_email"] = email_stripped
+        else:
+            # Purge any identifying fields entered on a previous confidential
+            # pass — they must not linger in the Redis session for an anonymous
+            # report.
+            state.pop("confidential_name", None)
+            state.pop("confidential_contact", None)
+            state.pop("secure_email", None)
 
         state["step"] = _STEP_LOCATION if has_locations else _STEP_CATEGORY
         await _save_submission(redis, session_id, state)
@@ -718,9 +731,9 @@ async def whistleblower_download_attachment(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
         data = attachment.data
 
-    safe_name = attachment.filename.replace('"', "")
+    from app.services.attachment import content_disposition_attachment
     return Response(
         content=data,
         media_type=attachment.content_type,
-        headers={"Content-Disposition": f'attachment; filename="{safe_name}"'},
+        headers={"Content-Disposition": content_disposition_attachment(attachment.filename)},
     )

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -570,8 +570,14 @@ async def status_post(
     db: AsyncSession = Depends(get_db),
     _csrf: None = Depends(validate_csrf),
 ) -> Response:
-    if not await rl.check_whistleblower_attempts(redis, session_token):
-        lockout_ttl = await rl.get_whistleblower_lockout_ttl(redis, session_token)
+    # Rate-limit PIN guessing against the *target case number*, not the
+    # client-supplied session token. The token is minted fresh on every GET
+    # /status and echoed back, so keying the lockout on it let an attacker reset
+    # the counter simply by re-fetching the page before each guess.
+    rl_key = case_number.strip().upper()
+
+    if not await rl.check_whistleblower_attempts(redis, rl_key):
+        lockout_ttl = await rl.get_whistleblower_lockout_ttl(redis, rl_key)
         return render(
             request,
             "status.html",
@@ -586,8 +592,8 @@ async def status_post(
     report = await report_service.get_report_by_credentials(db, case_number.strip(), pin.strip())
 
     if report is None:
-        remaining = await rl.remaining_whistleblower_attempts(redis, session_token)
-        await rl.record_whistleblower_failure(redis, session_token)
+        remaining = await rl.remaining_whistleblower_attempts(redis, rl_key)
+        await rl.record_whistleblower_failure(redis, rl_key)
         return render(
             request,
             "status.html",
@@ -600,7 +606,7 @@ async def status_post(
             status_code=401,
         )
 
-    await rl.reset_whistleblower_attempts(redis, session_token)
+    await rl.reset_whistleblower_attempts(redis, rl_key)
 
     status_session_key = secrets.token_urlsafe(32)
     await redis.setex(f"status-session:{status_session_key}", 7200, str(report.id))

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "OpenWhistle"
-    app_version: str = "1.1.0"
+    app_version: str = "1.1.1"
 
     # Logging
     log_level: str = "INFO"

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,10 @@
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Minimum SECRET_KEY length. The key is the root secret for admin JWT signing
+# AND (via SHA-256) the Fernet key that encrypts confidential whistleblower
+# identity — so a weak key collapses the platform's core protection.
+_MIN_SECRET_KEY_LEN = 32
 
 
 class Settings(BaseSettings):
@@ -16,6 +22,18 @@ class Settings(BaseSettings):
 
     # Security — no default; must be set in environment
     secret_key: str
+
+    @field_validator("secret_key")
+    @classmethod
+    def _validate_secret_key(cls, v: str) -> str:
+        if len(v) < _MIN_SECRET_KEY_LEN:
+            raise ValueError(
+                f"SECRET_KEY must be at least {_MIN_SECRET_KEY_LEN} characters "
+                "(it is the root key for admin authentication and confidential-"
+                "identity encryption). Generate one with e.g. "
+                "`python -c 'import secrets; print(secrets.token_urlsafe(48))'`."
+            )
+        return v
 
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 60

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -73,7 +73,6 @@ class SecurityMiddleware:
                 mutable = MutableHeaders(scope=message)
                 for name, value in _SECURITY_HEADERS.items():
                     mutable[name] = value
-                mutable.update(_SECURITY_HEADERS)
                 # Remove server identification headers
                 for h in ("server", "x-powered-by"):
                     if h in mutable:

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,5 +1,7 @@
 """Security middleware: IP detection warning, security headers, no IP logging."""
 
+import secrets
+
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -18,23 +20,39 @@ _IP_REVEAL_HEADERS = frozenset(
 
 _REDIS_IP_WARNING_KEY = "openwhistle:ip_headers_detected"
 
-_SECURITY_HEADERS: dict[str, str] = {
+# Static headers that never vary per request. The Content-Security-Policy is
+# built per request in _build_csp() because it carries a per-response nonce.
+_STATIC_SECURITY_HEADERS: dict[str, str] = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
     "X-XSS-Protection": "0",
     "Referrer-Policy": "no-referrer",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
-    "Content-Security-Policy": (
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+}
+
+
+def _build_csp(nonce: str) -> str:
+    """Strict Content-Security-Policy with no 'unsafe-inline'.
+
+    Inline <script>/<style> blocks are allowed only when they carry the
+    matching per-response nonce; inline event-handler attributes and inline
+    style="" attributes are forbidden by the policy (they carry no nonce), so
+    all interactivity/styling must live in nonce'd blocks, external files, or
+    be applied via the CSSOM.
+    """
+    return (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline'; "
-        "style-src 'self' 'unsafe-inline'; "
+        f"script-src 'self' 'nonce-{nonce}'; "
+        f"style-src 'self' 'nonce-{nonce}'; "
         "font-src 'self'; "
         "img-src 'self' data:; "
         "connect-src 'self'; "
+        "base-uri 'self'; "
+        "form-action 'self'; "
+        "object-src 'none'; "
         "frame-ancestors 'none';"
-    ),
-    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-}
+    )
 
 
 class SecurityMiddleware:
@@ -51,6 +69,15 @@ class SecurityMiddleware:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
+
+        # Per-response CSP nonce, exposed to templates via request.state so that
+        # inline <script>/<style> blocks can carry nonce="{{ request.state.csp_nonce }}".
+        nonce = secrets.token_urlsafe(16)
+        state = scope.get("state")
+        if state is None:
+            state = {}
+            scope["state"] = state
+        state["csp_nonce"] = nonce
 
         # scope["headers"] is list[tuple[bytes, bytes]] in the ASGI spec
         raw_headers: list[tuple[bytes, bytes]] = list(scope.get("headers", []))
@@ -71,8 +98,9 @@ class SecurityMiddleware:
         async def send_with_security(message: Message) -> None:
             if message["type"] == "http.response.start":
                 mutable = MutableHeaders(scope=message)
-                for name, value in _SECURITY_HEADERS.items():
+                for name, value in _STATIC_SECURITY_HEADERS.items():
                     mutable[name] = value
+                mutable["Content-Security-Policy"] = _build_csp(nonce)
                 # Remove server identification headers
                 for h in ("server", "x-powered-by"):
                     if h in mutable:

--- a/app/services/attachment.py
+++ b/app/services/attachment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import uuid
 from pathlib import Path
+from urllib.parse import quote
 
 from fastapi import UploadFile
 from sqlalchemy import select
@@ -54,6 +55,21 @@ def sanitize_filename(filename: str) -> str:
     return name
 
 
+def content_disposition_attachment(filename: str) -> str:
+    """Build a Content-Disposition header value safe for any filename.
+
+    Response headers are latin-1 encoded, so a raw non-Latin-1 filename (CJK,
+    Cyrillic, emoji, …) raises UnicodeEncodeError and 500s the download. Emit an
+    ASCII-only ``filename`` fallback plus an RFC 5987 ``filename*`` with the full
+    UTF-8 name for modern clients.
+    """
+    ascii_name = filename.encode("ascii", "ignore").decode("ascii").replace('"', "").strip()
+    if not ascii_name:
+        ascii_name = "attachment"
+    utf8_name = quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"
+
+
 def validate_file(filename: str, content_type: str, size: int) -> str | None:
     """Return an error string if the file is invalid, or None if it's acceptable."""
     if size > MAX_SIZE_BYTES:
@@ -92,7 +108,14 @@ async def read_upload_files(
         if not upload.filename or upload.filename.strip() == "":
             continue
 
-        data = await upload.read()
+        # Enforce the count limit before touching the next file's bytes, so a
+        # flood of parts can't force us to read them all into memory first.
+        if len(result) >= MAX_ATTACHMENTS:
+            return [], f"Too many files. Maximum {MAX_ATTACHMENTS} attachments per report."
+
+        # Bounded read: pull at most one byte past the limit so an oversized
+        # file is rejected without buffering its entire (potentially huge) body.
+        data = await upload.read(MAX_SIZE_BYTES + 1)
         if len(data) == 0:
             continue
 
@@ -103,9 +126,6 @@ async def read_upload_files(
             return [], error
 
         result.append((name, content_type, data))
-
-    if len(result) > MAX_ATTACHMENTS:
-        return [], f"Too many files. Maximum {MAX_ATTACHMENTS} attachments per report."
 
     return result, None
 

--- a/app/services/crypto.py
+++ b/app/services/crypto.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 
 from cryptography.fernet import Fernet
+
+log = logging.getLogger(__name__)
 
 
 def _make_fernet() -> Fernet:
@@ -40,4 +43,11 @@ def decrypt_or_none(token: str | None) -> str | None:
     try:
         return decrypt(token)
     except Exception:
+        # A non-empty token that fails to decrypt is NOT the same as an absent
+        # field: it means corruption, a rotated SECRET_KEY, or tampering. Log it
+        # so an operator can investigate rather than silently showing "blank".
+        log.warning(
+            "Failed to decrypt a confidential field; showing it as empty. "
+            "This indicates data corruption or a rotated SECRET_KEY."
+        )
         return None

--- a/app/services/pdf.py
+++ b/app/services/pdf.py
@@ -143,7 +143,7 @@ def generate_report_pdf(report: Report) -> bytes:
         for note in report.notes:
             pdf.set_font("Helvetica", "B", 9)
             pdf.cell(
-                0, 5, f"{note.author_username}  ·  {_fmt_dt(note.created_at)}",
+                0, 5, f"{_safe(note.author_username)}  ·  {_fmt_dt(note.created_at)}",
                 new_x=XPos.LMARGIN, new_y=YPos.NEXT,
             )
             pdf.set_font("Helvetica", "", 10)

--- a/app/services/pin.py
+++ b/app/services/pin.py
@@ -21,6 +21,10 @@ async def generate_case_number(db: AsyncSession) -> str:
 
     Uses MAX instead of COUNT so hard-deleting a report never causes a
     subsequent submission to reuse a previously-issued case number.
+
+    Case numbers are globally unique; concurrent submissions can read the same
+    MAX before either commits, so callers must be prepared to retry on the
+    unique-constraint violation (see ``create_report``).
     """
     year = datetime.now(UTC).year
     result = await db.execute(

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -13,8 +13,16 @@ from datetime import UTC, datetime, timedelta
 
 log = logging.getLogger(__name__)
 
-# Redis key TTL for dedup locks: slightly longer than the schedule interval
-_DEDUP_TTL_SECONDS = 3600  # 1 hour — prevents double-fire even on restarts
+
+def _dedup_ttl_seconds(days_left: int) -> int:
+    """TTL for a reminder dedup key.
+
+    A fixed 1-hour TTL was far shorter than the multi-day warn window, so the
+    key expired every couple of scheduler ticks and the same reminder re-fired
+    for days. Instead suppress re-reminders until the deadline itself has passed
+    (plus a one-day buffer), giving one reminder per warn-window entry.
+    """
+    return max(days_left, 0) * 86400 + 86400
 
 
 def _ack_dedup_key(case_number: str) -> str:
@@ -58,8 +66,13 @@ async def send_sla_reminders() -> None:
             reports = result.scalars().all()
 
             for report in reports:
-                await _check_ack_reminder(report, now, db, redis, settings)
-                await _check_feedback_reminder(report, now, db, redis, settings)
+                # Isolate per-report failures: one bad row must not abort SLA
+                # checks for every other pending report in this run.
+                try:
+                    await _check_ack_reminder(report, now, db, redis, settings)
+                    await _check_feedback_reminder(report, now, db, redis, settings)
+                except Exception:  # noqa: BLE001
+                    log.exception("SLA reminder check failed for a report; continuing")
     finally:
         await engine.dispose()
 
@@ -99,7 +112,7 @@ async def _check_ack_reminder(
         report=r,
         settings=cfg,
     )
-    await red.setex(key, _DEDUP_TTL_SECONDS, "1")
+    await red.setex(key, _dedup_ttl_seconds(days_left), "1")
     log.info("ACK reminder sent for %s (%d days left)", r.case_number, days_left)
 
 
@@ -137,7 +150,7 @@ async def _check_feedback_reminder(
         report=r,
         settings=cfg,
     )
-    await red.setex(key, _DEDUP_TTL_SECONDS, "1")
+    await red.setex(key, _dedup_ttl_seconds(days_left), "1")
     log.info("Feedback reminder sent for %s (%d days left)", r.case_number, days_left)
 
 

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -56,6 +56,13 @@ async def send_sla_reminders() -> None:
     try:
         async with session_factory() as db:
             redis = await get_redis()
+            # Distributed lock: the app runs stateless/scaled, so every replica
+            # starts its own scheduler. Only one may run each cycle, else audit
+            # entries and outbound notifications are duplicated per replica.
+            if not await redis.set(
+                "openwhistle:job_lock:sla_reminders", "1", nx=True, ex=1500
+            ):
+                return
             now = datetime.now(UTC)
 
             result = await db.execute(

--- a/app/services/reminders.py
+++ b/app/services/reminders.py
@@ -59,27 +59,33 @@ async def send_sla_reminders() -> None:
             # Distributed lock: the app runs stateless/scaled, so every replica
             # starts its own scheduler. Only one may run each cycle, else audit
             # entries and outbound notifications are duplicated per replica.
-            if not await redis.set(
-                "openwhistle:job_lock:sla_reminders", "1", nx=True, ex=1500
-            ):
+            # Acquire → run → release; the TTL is only a crash safety-net.
+            lock_key = "openwhistle:job_lock:sla_reminders"
+            if not await redis.set(lock_key, "1", nx=True, ex=300):
                 return
-            now = datetime.now(UTC)
+            try:
+                now = datetime.now(UTC)
 
-            result = await db.execute(
-                select(Report).where(
-                    Report.status.notin_([ReportStatus.closed])
+                result = await db.execute(
+                    select(Report).where(
+                        Report.status.notin_([ReportStatus.closed])
+                    )
                 )
-            )
-            reports = result.scalars().all()
+                reports = result.scalars().all()
 
-            for report in reports:
-                # Isolate per-report failures: one bad row must not abort SLA
-                # checks for every other pending report in this run.
+                for report in reports:
+                    # Isolate per-report failures: one bad row must not abort SLA
+                    # checks for every other pending report in this run.
+                    try:
+                        await _check_ack_reminder(report, now, db, redis, settings)
+                        await _check_feedback_reminder(report, now, db, redis, settings)
+                    except Exception:  # noqa: BLE001
+                        log.exception("SLA reminder check failed for a report; continuing")
+            finally:
                 try:
-                    await _check_ack_reminder(report, now, db, redis, settings)
-                    await _check_feedback_reminder(report, now, db, redis, settings)
-                except Exception:  # noqa: BLE001
-                    log.exception("SLA reminder check failed for a report; continuing")
+                    await redis.delete(lock_key)
+                except Exception:  # noqa: BLE001, S110
+                    pass
     finally:
         await engine.dispose()
 

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -327,6 +327,7 @@ async def get_reports_paginated(
     assigned_to_id: uuid.UUID | None = None,
     location_id: uuid.UUID | None = None,
     org_id: uuid.UUID | None = None,
+    scope_org: bool = False,
 ) -> tuple[list[Report], int]:
     page = max(1, page)
     per_page = max(1, min(100, per_page))
@@ -342,7 +343,9 @@ async def get_reports_paginated(
         base_q = base_q.where(Report.assigned_to_id == assigned_to_id)
     if location_id is not None:
         base_q = base_q.where(Report.location_id == location_id)
-    if org_id is not None:
+    if scope_org or org_id is not None:
+        # `== org_id` renders `IS NULL` when org_id is None, so an org-less
+        # caller is correctly restricted to org-less reports rather than all.
         base_q = base_q.where(Report.org_id == org_id)
 
     count_result = await db.execute(select(func.count()).select_from(base_q.subquery()))

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -450,6 +450,22 @@ async def get_link(
     return result.scalar_one_or_none()
 
 
+async def get_active_deletion_request(
+    db: AsyncSession, report_id: uuid.UUID, for_update: bool = False
+) -> DeletionRequest | None:
+    """Fetch a report's pending deletion request, optionally locking the row.
+
+    confirm-delete uses ``for_update=True`` so a concurrent cancel cannot delete
+    the request between the confirm handler reading it and executing the
+    deletion (which would otherwise delete the report despite the withdrawal).
+    """
+    stmt = select(DeletionRequest).where(DeletionRequest.report_id == report_id)
+    if for_update:
+        stmt = stmt.with_for_update()
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
 async def get_link_between(
     db: AsyncSession, report_id_a: uuid.UUID, report_id_b: uuid.UUID
 ) -> CaseLink | None:

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -296,6 +296,7 @@ async def get_reports_paginated(
     sort_dir: SortDir = "desc",
     assigned_to_id: uuid.UUID | None = None,
     location_id: uuid.UUID | None = None,
+    org_id: uuid.UUID | None = None,
 ) -> tuple[list[Report], int]:
     page = max(1, page)
     per_page = max(1, min(100, per_page))
@@ -311,6 +312,8 @@ async def get_reports_paginated(
         base_q = base_q.where(Report.assigned_to_id == assigned_to_id)
     if location_id is not None:
         base_q = base_q.where(Report.location_id == location_id)
+    if org_id is not None:
+        base_q = base_q.where(Report.org_id == org_id)
 
     count_result = await db.execute(select(func.count()).select_from(base_q.subquery()))
     total: int = count_result.scalar_one()

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -76,6 +76,8 @@ async def create_report(
     secure_email_enc: str | None = None,
 ) -> tuple[Report, str]:
     """Create a new whistleblower report. Returns (report, plain_pin)."""
+    from sqlalchemy.exc import IntegrityError
+
     from app.config import settings
     from app.services.encryption import (
         encrypt_dek,
@@ -84,7 +86,6 @@ async def create_report(
         make_report_fernet,
     )
 
-    case_number = await generate_case_number(db)
     plain_pin = generate_pin()
     pin_hash = hash_pin(plain_pin)
 
@@ -96,38 +97,51 @@ async def create_report(
 
     default_org_id = await _get_default_org_id(db)
 
-    report = Report(
-        id=uuid.uuid4(),
-        case_number=case_number,
-        pin_hash=pin_hash,
-        org_id=default_org_id,
-        category=category,
-        description=enc_description,
-        encrypted_dek=encrypted_dek,
-        status=ReportStatus.received,
-        submission_mode=submission_mode,
-        location_id=location_id,
-        confidential_name=confidential_name_enc,
-        confidential_contact=confidential_contact_enc,
-        secure_email=secure_email_enc,
-    )
-    db.add(report)
-
     strings = _load(lang)
     fallback = _load(_DEFAULT)
     receipt_text = strings.get("system.receipt_message") or fallback.get("system.receipt_message")
-
     enc_receipt = encrypt_field(report_fernet, receipt_text or "")
-    receipt_msg = ReportMessage(
-        id=uuid.uuid4(),
-        report_id=report.id,
-        sender=ReportSender.admin,
-        content=enc_receipt,
-    )
-    db.add(receipt_msg)
-    await db.commit()
-    await db.refresh(report)
-    return report, plain_pin
+
+    # generate_case_number reads MAX() without a lock, so two concurrent
+    # submissions can compute the same next number. Retry on the resulting
+    # unique-constraint violation instead of surfacing a 500 to the reporter.
+    last_exc: IntegrityError | None = None
+    for _attempt in range(5):
+        report = Report(
+            id=uuid.uuid4(),
+            case_number=await generate_case_number(db),
+            pin_hash=pin_hash,
+            org_id=default_org_id,
+            category=category,
+            description=enc_description,
+            encrypted_dek=encrypted_dek,
+            status=ReportStatus.received,
+            submission_mode=submission_mode,
+            location_id=location_id,
+            confidential_name=confidential_name_enc,
+            confidential_contact=confidential_contact_enc,
+            secure_email=secure_email_enc,
+        )
+        db.add(report)
+        db.add(
+            ReportMessage(
+                id=uuid.uuid4(),
+                report_id=report.id,
+                sender=ReportSender.admin,
+                content=enc_receipt,
+            )
+        )
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            last_exc = exc
+            await db.rollback()
+            continue
+        await db.refresh(report)
+        return report, plain_pin
+
+    assert last_exc is not None
+    raise last_exc
 
 
 def decrypt_report_fields(report: Report) -> tuple[str, list[str]]:
@@ -141,9 +155,12 @@ def decrypt_report_fields(report: Report) -> tuple[str, list[str]]:
 
     if report.encrypted_dek:
         fernet = make_report_fernet(report.encrypted_dek, settings.secret_key)
-        description = decrypt_field_safe(fernet, report.description) or report.description
+        # Use an explicit None check, not `or`: a value that legitimately
+        # decrypts to an empty string must NOT fall back to the raw ciphertext.
+        dec_desc = decrypt_field_safe(fernet, report.description)
+        description = dec_desc if dec_desc is not None else report.description
         msg_contents = [
-            decrypt_field_safe(fernet, m.content) or m.content
+            dec if (dec := decrypt_field_safe(fernet, m.content)) is not None else m.content
             for m in report.messages
         ]
     else:
@@ -227,9 +244,13 @@ async def add_admin_message(
 
 
 async def acknowledge_report(db: AsyncSession, report: Report) -> Report:
-    now = datetime.now(UTC)
-    report.acknowledged_at = now
-    report.feedback_due_at = now + timedelta(days=90)
+    # Idempotent: the acknowledgement timestamp and the derived statutory
+    # feedback deadline (HinSchG §17) are set exactly once. Re-invoking must
+    # never push the deadline further out.
+    if report.acknowledged_at is None:
+        now = datetime.now(UTC)
+        report.acknowledged_at = now
+        report.feedback_due_at = now + timedelta(days=90)
     if report.status == ReportStatus.received:
         report.status = ReportStatus.in_review
     await db.commit()
@@ -245,8 +266,17 @@ async def update_report_status(
     db: AsyncSession, report: Report, new_status: ReportStatus
 ) -> Report:
     report.status = new_status
-    if new_status == ReportStatus.closed and report.closed_at is None:
-        report.closed_at = datetime.now(UTC)
+    if new_status == ReportStatus.closed:
+        # Stamp the closure time on the first close, and refresh it on a
+        # re-close after a reopen (closed_at was cleared below on reopen), so
+        # the retention clock always runs from the *most recent* closure.
+        if report.closed_at is None:
+            report.closed_at = datetime.now(UTC)
+    elif report.closed_at is not None:
+        # Reopening (leaving the closed state) clears the closure timestamp,
+        # otherwise the retention job would delete the report based on a stale
+        # original closure date, far before the statutory minimum has elapsed.
+        report.closed_at = None
     await db.commit()
     await db.refresh(report)
     return report
@@ -414,6 +444,19 @@ async def get_link(
     db: AsyncSession, link_id: uuid.UUID
 ) -> CaseLink | None:
     result = await db.execute(select(CaseLink).where(CaseLink.id == link_id))
+    return result.scalar_one_or_none()
+
+
+async def get_link_between(
+    db: AsyncSession, report_id_a: uuid.UUID, report_id_b: uuid.UUID
+) -> CaseLink | None:
+    """Return the existing link between two reports (order-independent), if any."""
+    norm_a, norm_b = _normalize_ids(report_id_a, report_id_b)
+    result = await db.execute(
+        select(CaseLink).where(
+            CaseLink.report_id_a == norm_a, CaseLink.report_id_b == norm_b
+        )
+    )
     return result.scalar_one_or_none()
 
 

--- a/app/services/retention.py
+++ b/app/services/retention.py
@@ -39,6 +39,14 @@ async def run_retention_cleanup() -> None:
 
     from app.models.audit import AuditLog
     from app.models.report import Report, ReportStatus
+    from app.redis_client import get_redis
+
+    # Distributed lock: with multiple stateless replicas each running a
+    # scheduler, only one may perform the daily cleanup, otherwise the same
+    # deletions are audited twice. TTL well under the 24h cron interval.
+    redis = await get_redis()
+    if not await redis.set("openwhistle:job_lock:retention", "1", nx=True, ex=3600):
+        return
 
     engine = create_async_engine(settings.database_url, echo=False)
     cutoff = datetime.now(UTC) - timedelta(days=settings.retention_days)

--- a/app/services/retention.py
+++ b/app/services/retention.py
@@ -34,25 +34,30 @@ async def run_retention_cleanup() -> None:
     if not settings.retention_enabled:
         return
 
+    from redis.asyncio import Redis
     from sqlalchemy import delete, select
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     from app.models.audit import AuditLog
     from app.models.report import Report, ReportStatus
-    from app.redis_client import get_redis
 
     # Distributed lock: with multiple stateless replicas each running a
     # scheduler, only one may perform the daily cleanup, otherwise the same
-    # deletions are audited twice. TTL well under the 24h cron interval.
-    redis = await get_redis()
-    if not await redis.set("openwhistle:job_lock:retention", "1", nx=True, ex=3600):
-        return
-
-    engine = create_async_engine(settings.database_url, echo=False)
-    cutoff = datetime.now(UTC) - timedelta(days=settings.retention_days)
+    # deletions are audited twice. Acquire → run → release; the TTL is only a
+    # crash safety-net. Use a dedicated short-lived connection (not the shared
+    # request-scoped client) so the job never binds/poisons that client's loop.
+    lock_key = "openwhistle:job_lock:retention"
+    lock_redis = Redis.from_url(settings.redis_url)
+    acquired = False
+    engine = None
     deleted_count = 0
-
     try:
+        acquired = bool(await lock_redis.set(lock_key, "1", nx=True, ex=600))
+        if not acquired:
+            return
+
+        engine = create_async_engine(settings.database_url, echo=False)
+        cutoff = datetime.now(UTC) - timedelta(days=settings.retention_days)
         session_factory = async_sessionmaker(engine, expire_on_commit=False)
         async with session_factory() as db:
             result = await db.execute(
@@ -94,7 +99,16 @@ async def run_retention_cleanup() -> None:
     except Exception:
         log.exception("Retention cleanup failed")
     finally:
-        await engine.dispose()
+        if engine is not None:
+            await engine.dispose()
+        # Release the lock (only if we hold it) so the next run — or the next
+        # test — can acquire cleanly; then drop the dedicated connection.
+        if acquired:
+            try:
+                await lock_redis.delete(lock_key)
+            except Exception:  # noqa: BLE001, S110
+                pass
+        await lock_redis.aclose()
 
     if deleted_count:
         log.info("Retention cleanup complete: %d report(s) deleted.", deleted_count)

--- a/app/services/retention.py
+++ b/app/services/retention.py
@@ -47,14 +47,21 @@ async def run_retention_cleanup() -> None:
     # crash safety-net. Use a dedicated short-lived connection (not the shared
     # request-scoped client) so the job never binds/poisons that client's loop.
     lock_key = "openwhistle:job_lock:retention"
-    lock_redis = Redis.from_url(settings.redis_url)
+    lock_redis = None
     acquired = False
     engine = None
     deleted_count = 0
     try:
-        acquired = bool(await lock_redis.set(lock_key, "1", nx=True, ex=600))
-        if not acquired:
-            return
+        # Best-effort: if the lock backend is unreachable, still run the job
+        # (retention is a compliance obligation) — only skip when we positively
+        # observe another replica holding the lock.
+        try:
+            lock_redis = Redis.from_url(settings.redis_url)
+            if not await lock_redis.set(lock_key, "1", nx=True, ex=600):
+                return
+            acquired = True
+        except Exception:  # noqa: BLE001
+            log.warning("Retention job lock unavailable; proceeding without it")
 
         engine = create_async_engine(settings.database_url, echo=False)
         cutoff = datetime.now(UTC) - timedelta(days=settings.retention_days)
@@ -103,12 +110,13 @@ async def run_retention_cleanup() -> None:
             await engine.dispose()
         # Release the lock (only if we hold it) so the next run — or the next
         # test — can acquire cleanly; then drop the dedicated connection.
-        if acquired:
-            try:
-                await lock_redis.delete(lock_key)
-            except Exception:  # noqa: BLE001, S110
-                pass
-        await lock_redis.aclose()
+        if lock_redis is not None:
+            if acquired:
+                try:
+                    await lock_redis.delete(lock_key)
+                except Exception:  # noqa: BLE001, S110
+                    pass
+            await lock_redis.aclose()
 
     if deleted_count:
         log.info("Retention cleanup complete: %d report(s) deleted.", deleted_count)

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -41,6 +41,15 @@ async def get_user_by_id(db: AsyncSession, user_id: uuid.UUID) -> AdminUser | No
     return result.scalar_one_or_none()
 
 
+async def get_user_by_username_ci(db: AsyncSession, username: str) -> AdminUser | None:
+    """Case-insensitive username lookup — prevents confusable duplicate accounts
+    (e.g. ``admin`` vs ``Admin``) that could be used for admin impersonation."""
+    result = await db.execute(
+        select(AdminUser).where(func.lower(AdminUser.username) == username.strip().lower())
+    )
+    return result.scalar_one_or_none()
+
+
 async def count_active_admins(db: AsyncSession) -> int:
     result = await db.execute(
         select(func.count(AdminUser.id)).where(

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import uuid
 
 import pyotp
@@ -10,6 +11,24 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.user import AdminRole, AdminUser
 from app.services.auth import hash_password
+
+# Locally-created usernames are restricted to an unambiguous allowlist. This
+# prevents storing quotes / JS metacharacters that could break out of an
+# HTML/JS context in the admin UI (defense in depth alongside contextual output
+# encoding). Directory-provisioned identities (OIDC/LDAP) do not pass through
+# this validator.
+_USERNAME_RE = re.compile(r"^[A-Za-z0-9._@ -]{3,64}$")
+
+
+def validate_username(username: str) -> str:
+    """Return the trimmed username or raise ValueError if it is not allowed."""
+    candidate = username.strip()
+    if not _USERNAME_RE.fullmatch(candidate):
+        raise ValueError(
+            "Username must be 3–64 characters and may only contain letters, "
+            "digits, spaces and the characters . _ @ -"
+        )
+    return candidate
 
 
 async def get_all_users(db: AsyncSession) -> list[AdminUser]:
@@ -38,7 +57,11 @@ async def create_user(
     password: str,
     role: AdminRole = AdminRole.admin,
 ) -> tuple[AdminUser, str]:
-    """Create a new admin user. Returns (user, totp_secret)."""
+    """Create a new admin user. Returns (user, totp_secret).
+
+    Raises ValueError if the username contains disallowed characters.
+    """
+    username = validate_username(username)
     totp_secret = pyotp.random_base32()
     user = AdminUser(
         id=uuid.uuid4(),

--- a/app/services/users.py
+++ b/app/services/users.py
@@ -51,6 +51,17 @@ async def count_active_admins(db: AsyncSession) -> int:
     return result.scalar_one()
 
 
+async def count_active_privileged_admins(db: AsyncSession) -> int:
+    """Active accounts that can administer the instance (admin OR superadmin)."""
+    result = await db.execute(
+        select(func.count(AdminUser.id)).where(
+            AdminUser.role.in_([AdminRole.admin, AdminRole.superadmin]),
+            AdminUser.is_active.is_(True),
+        )
+    )
+    return result.scalar_one()
+
+
 async def create_user(
     db: AsyncSession,
     username: str,

--- a/app/static/js/site.js
+++ b/app/static/js/site.js
@@ -185,7 +185,17 @@ window.dismissIpWarning = async function (btn) {
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('form').forEach((form) => {
-        form.addEventListener('submit', () => {
+        form.addEventListener('submit', (e) => {
+            // Unobtrusive confirmation. The prompt text lives in a data-confirm
+            // attribute (HTML-attribute autoescaped by the template) and is
+            // passed to confirm() as a runtime string — never interpolated into
+            // an inline event handler, so untrusted values (e.g. usernames)
+            // cannot break out into script.
+            const confirmMsg = form.getAttribute('data-confirm');
+            if (confirmMsg && !window.confirm(confirmMsg)) {
+                e.preventDefault();
+                return;
+            }
             const btn = form.querySelector('[type="submit"]');
             if (btn) {
                 btn.disabled = true;

--- a/app/static/js/site.js
+++ b/app/static/js/site.js
@@ -34,6 +34,12 @@
         try { localStorage.setItem(STORAGE_KEY, next); } catch { /* private browsing */ }
     };
 
+    // Wire the toggle without an inline onclick (strict CSP forbids inline handlers)
+    document.addEventListener('DOMContentLoaded', () => {
+        const toggle = document.getElementById('theme-toggle');
+        if (toggle) toggle.addEventListener('click', window.toggleTheme);
+    });
+
     // Listen for system preference changes
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
         if (!savedTheme()) applyTheme(e.matches ? 'dark' : 'light');
@@ -180,6 +186,31 @@ window.dismissIpWarning = async function (btn) {
         banner.style.display = 'none';
     };
 })();
+
+// ─── Delegated data-action dispatch ─────────────────────────────────────────
+// Replaces inline on* handlers (forbidden by the strict, nonce-based CSP).
+// Elements opt in with data-action="…"; extra inputs travel in data-* attrs.
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.body.addEventListener('click', (e) => {
+        const el = e.target.closest('[data-action]');
+        if (!el) return;
+        switch (el.dataset.action) {
+            case 'session-extend':
+                if (window.sessionExtend) window.sessionExtend();
+                break;
+            case 'session-dismiss':
+                if (window.sessionDismiss) window.sessionDismiss();
+                break;
+            case 'dismiss-ip-warning':
+                if (window.dismissIpWarning) window.dismissIpWarning(el);
+                break;
+            case 'copy':
+                if (window.copyToClipboard) window.copyToClipboard(el.dataset.copy || '', el);
+                break;
+        }
+    });
+});
 
 // ─── Prevent double-submit ─────────────────────────────────────────────────
 

--- a/app/templates/admin/audit_log.html
+++ b/app/templates/admin/audit_log.html
@@ -2,6 +2,23 @@
 
 {% block title %}{{ t('admin.audit.title') }} | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+    .aud-header { display:flex;align-items:flex-end;justify-content:space-between;flex-wrap:wrap;gap:1rem; }
+    .aud-filter-panel { margin-bottom:1.25rem; }
+    .aud-filter-form { display:flex;gap:0.75rem;flex-wrap:wrap;align-items:flex-end; }
+    .aud-filter-group { margin:0;flex:1;min-width:180px; }
+    .aud-time-cell { font-size:0.78rem;white-space:nowrap;color:var(--muted); }
+    .aud-admin-cell { font-size:0.85rem;font-weight:600; }
+    .aud-action-badge { font-family:var(--font-mono);font-size:0.78rem;color:var(--accent);background:var(--accent-subtle);padding:0.15rem 0.4rem;border-radius:4px; }
+    .aud-report-link { font-size:0.78rem; }
+    .aud-detail-cell { font-size:0.78rem;color:var(--muted);font-family:var(--font-mono);max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap; }
+    .aud-empty { text-align:center;padding:3rem 1rem; }
+    .aud-empty-icon { font-size:2.5rem;margin-bottom:1rem;opacity:0.3; }
+    .aud-empty-text { font-size:1rem;color:var(--muted); }
+</style>
+{% endblock %}
+
 {% block nav_links %}
 <li><a href="/admin/dashboard">{{ t('admin.dashboard.title') }}</a></li>
 <li><a href="/admin/stats">{{ t('admin.nav.stats') }}</a></li>
@@ -17,7 +34,7 @@
 
 {% block content %}
 <div class="container">
-    <div class="page-header" style="display:flex;align-items:flex-end;justify-content:space-between;flex-wrap:wrap;gap:1rem;">
+    <div class="page-header aud-header">
         <div>
             <div class="page-eyebrow">{{ t('admin.audit.eyebrow') }}</div>
             <h1>{{ t('admin.audit.title') }}</h1>
@@ -28,15 +45,15 @@
     </div>
 
     {# Filter bar #}
-    <div class="panel" style="margin-bottom:1.25rem;">
-        <form method="get" action="/admin/audit-log" style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:flex-end;">
-            <div class="form-group" style="margin:0;flex:1;min-width:180px;">
+    <div class="panel aud-filter-panel">
+        <form method="get" action="/admin/audit-log" class="aud-filter-form">
+            <div class="form-group aud-filter-group">
                 <label class="form-label" for="action-filter">{{ t('admin.audit.filter.action') }}</label>
                 <input type="text" class="form-control" id="action-filter" name="action"
                     value="{{ action_filter }}"
                     placeholder="{{ t('admin.audit.filter.all') }}">
             </div>
-            <div class="form-group" style="margin:0;flex:1;min-width:180px;">
+            <div class="form-group aud-filter-group">
                 <label class="form-label" for="report-filter">{{ t('admin.audit.filter.report_id') }}</label>
                 <input type="text" class="form-control" id="report-filter" name="report_id"
                     value="{{ report_id_filter }}"
@@ -65,25 +82,25 @@
                 <tbody>
                     {% for entry in entries %}
                     <tr>
-                        <td class="mono" style="font-size:0.78rem;white-space:nowrap;color:var(--muted);">
+                        <td class="mono aud-time-cell">
                             <time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</time>
                         </td>
-                        <td style="font-size:0.85rem;font-weight:600;">{{ entry.admin_username or 'N/A' }}</td>
+                        <td class="aud-admin-cell">{{ entry.admin_username or 'N/A' }}</td>
                         <td>
-                            <span style="font-family:var(--font-mono);font-size:0.78rem;color:var(--accent);background:var(--accent-subtle);padding:0.15rem 0.4rem;border-radius:4px;">
+                            <span class="aud-action-badge">
                                 {{ entry.action }}
                             </span>
                         </td>
                         <td>
                             {% if entry.report_id %}
-                            <a href="/admin/reports/{{ entry.report_id }}" class="mono" style="font-size:0.78rem;">
+                            <a href="/admin/reports/{{ entry.report_id }}" class="mono aud-report-link">
                                 {{ entry.report_id | string | truncate(13, true, '…') }}
                             </a>
                             {% else %}
                             N/A
                             {% endif %}
                         </td>
-                        <td style="font-size:0.78rem;color:var(--muted);font-family:var(--font-mono);max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="{{ entry.detail or '' }}">
+                        <td class="aud-detail-cell" title="{{ entry.detail or '' }}">
                             {{ entry.detail or '' }}
                         </td>
                     </tr>
@@ -117,9 +134,9 @@
         {% endif %}
 
         {% else %}
-        <div style="text-align:center;padding:3rem 1rem;">
-            <div style="font-size:2.5rem;margin-bottom:1rem;opacity:0.3;">&#128221;</div>
-            <p style="font-size:1rem;color:var(--muted);">{{ t('admin.audit.empty') }}</p>
+        <div class="aud-empty">
+            <div class="aud-empty-icon">&#128221;</div>
+            <p class="aud-empty-text">{{ t('admin.audit.empty') }}</p>
         </div>
         {% endif %}
     </div>

--- a/app/templates/admin/categories.html
+++ b/app/templates/admin/categories.html
@@ -2,6 +2,19 @@
 
 {% block title %}{{ t('admin.categories.title') }} | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.cat-grid { display:grid;grid-template-columns:1fr 2fr;gap:1.25rem;align-items:start; }
+.cat-row-inactive { opacity:0.5; }
+.cat-slug { font-size:0.82rem; }
+.cat-label-en { font-size:0.9rem; }
+.cat-label-de { font-size:0.9rem;color:var(--muted); }
+.cat-sort { font-size:0.82rem;color:var(--muted);text-align:center; }
+.cat-inline-form { display:inline; }
+.cat-empty { color:var(--muted);padding:1rem 0; }
+</style>
+{% endblock %}
+
 {% block nav_links %}
 <li><a href="/admin/dashboard">{{ t('admin.dashboard.title') }}</a></li>
 <li><a href="/admin/stats">{{ t('admin.nav.stats') }}</a></li>
@@ -22,7 +35,7 @@
         <h1>{{ t('admin.categories.title') }}</h1>
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 2fr;gap:1.25rem;align-items:start;">
+    <div class="cat-grid">
 
         {# Add category form #}
         <div class="panel">
@@ -74,11 +87,11 @@
                     </thead>
                     <tbody>
                         {% for cat in categories %}
-                        <tr style="{% if not cat.is_active %}opacity:0.5;{% endif %}">
-                            <td class="mono" style="font-size:0.82rem;">{{ cat.slug }}</td>
-                            <td style="font-size:0.9rem;">{{ cat.label_en }}</td>
-                            <td style="font-size:0.9rem;color:var(--muted);">{{ cat.label_de }}</td>
-                            <td style="font-size:0.82rem;color:var(--muted);text-align:center;">{{ cat.sort_order }}</td>
+                        <tr class="{% if not cat.is_active %}cat-row-inactive{% endif %}">
+                            <td class="mono cat-slug">{{ cat.slug }}</td>
+                            <td class="cat-label-en">{{ cat.label_en }}</td>
+                            <td class="cat-label-de">{{ cat.label_de }}</td>
+                            <td class="cat-sort">{{ cat.sort_order }}</td>
                             <td>
                                 {% if cat.is_default %}
                                 <span class="badge badge-received">{{ t('admin.categories.default') }}</span>
@@ -91,12 +104,12 @@
                             <td>
                                 {% if not cat.is_default %}
                                 {% if cat.is_active %}
-                                <form method="post" action="/admin/categories/{{ cat.id }}/deactivate" style="display:inline;">
+                                <form method="post" action="/admin/categories/{{ cat.id }}/deactivate" class="cat-inline-form">
                                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                                     <button type="submit" class="btn btn-secondary btn-sm">{{ t('admin.categories.deactivate') }}</button>
                                 </form>
                                 {% else %}
-                                <form method="post" action="/admin/categories/{{ cat.id }}/reactivate" style="display:inline;">
+                                <form method="post" action="/admin/categories/{{ cat.id }}/reactivate" class="cat-inline-form">
                                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                                     <button type="submit" class="btn btn-secondary btn-sm">{{ t('admin.categories.reactivate') }}</button>
                                 </form>
@@ -109,7 +122,7 @@
                 </table>
             </div>
             {% else %}
-            <p style="color:var(--muted);padding:1rem 0;">{{ t('admin.categories.empty') }}</p>
+            <p class="cat-empty">{{ t('admin.categories.empty') }}</p>
             {% endif %}
         </div>
 

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -1,5 +1,30 @@
 {% extends "base.html" %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.dash-page-header { display:flex;align-items:flex-end;justify-content:space-between;flex-wrap:wrap;gap:1rem; }
+.dash-logged-in-as { margin-top:0.25rem;font-size:0.8rem;color:var(--muted); }
+.dash-username { color:var(--accent);font-weight:600; }
+.dash-role-badge { margin-left:0.5rem;font-size:0.7rem; }
+.dash-alert-mb { margin-bottom:1.25rem; }
+.dash-shrink0 { flex-shrink:0; }
+.dash-stats-grid { display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:1rem;margin-bottom:2rem; }
+.dash-nowrap { white-space:nowrap; }
+.dash-category-cell { font-size:0.85rem;color:var(--body-text); }
+.dash-date-cell { font-size:0.78rem;color:var(--muted); }
+.dash-assignee-cell { font-size:0.82rem;color:var(--muted); }
+.dash-assignee-name { color:var(--body-text); }
+.dash-sla-cell { font-size:0.82rem; }
+.dash-empty-wrap { text-align:center;padding:3rem 1rem; }
+.dash-empty-wrap-lg { text-align:center;padding:3.5rem 1rem; }
+.dash-empty-icon { font-size:2.5rem;margin-bottom:1rem;opacity:0.3; }
+.dash-empty-title { font-size:1rem;font-weight:600;color:var(--body-text);margin-bottom:0.4rem; }
+.dash-empty-body { font-size:0.85rem;color:var(--muted); }
+.dash-mt-btn { margin-top:1rem; }
+.dash-mt-btn-lg { margin-top:1.25rem; }
+</style>
+{% endblock %}
+
 {% block title %}{{ t('admin.dashboard.title') }} | OpenWhistle{% endblock %}
 
 {% block nav_links %}
@@ -34,13 +59,13 @@
 
 {% block content %}
 <div class="container">
-    <div class="page-header" style="display:flex;align-items:flex-end;justify-content:space-between;flex-wrap:wrap;gap:1rem;">
+    <div class="page-header dash-page-header">
         <div>
             <div class="page-eyebrow">{{ t('admin.eyebrow') }}</div>
             <h1>{{ t('admin.dashboard.title') }}</h1>
-            <p style="margin-top:0.25rem;font-size:0.8rem;color:var(--muted);">
-                {{ t('admin.logged_in_as') }} <strong style="color:var(--accent);font-weight:600;">{{ user.username }}</strong>
-                <span class="badge badge-{{ user.role.value }}" style="margin-left:0.5rem;font-size:0.7rem;">{{ t('role.label.' + user.role.value) }}</span>
+            <p class="dash-logged-in-as">
+                {{ t('admin.logged_in_as') }} <strong class="dash-username">{{ user.username }}</strong>
+                <span class="badge badge-{{ user.role.value }} dash-role-badge">{{ t('role.label.' + user.role.value) }}</span>
             </p>
         </div>
         <a href="/submit" class="btn btn-secondary btn-sm" title="Opens the public submit form in this tab">{{ t('admin.view_submit') }}</a>
@@ -48,7 +73,7 @@
 
     {# Deletion success flash #}
     {% if deleted_case %}
-    <div class="alert alert-success" role="alert" style="margin-bottom:1.25rem;">
+    <div class="alert alert-success dash-alert-mb" role="alert">
         {{ t('admin.flash.deleted') }} <span class="mono">{{ deleted_case }}</span>
     </div>
     {% endif %}
@@ -64,14 +89,14 @@
             <br><br>
             {{ t('admin.ip_warning.hint') }}
         </div>
-        <button class="btn btn-danger btn-sm" onclick="dismissIpWarning(this)" style="flex-shrink:0;">
+        <button class="btn btn-danger btn-sm dash-shrink0" data-action="dismiss-ip-warning">
             {{ t('admin.ip_warning.dismiss') }}
         </button>
     </div>
     {% endif %}
 
     {# Summary stats cards - clickable filters #}
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:1rem;margin-bottom:2rem;">
+    <div class="dash-stats-grid">
         {% for label_key, status_val, cls in [
             ('admin.stats.received',          'received',          'badge-received'),
             ('admin.stats.in_review',         'in_review',         'badge-in_review'),
@@ -81,7 +106,7 @@
         {% set count = stats.get(status_val, 0) %}
         <a href="/admin/dashboard?status={{ status_val }}&sort={{ sort_by }}&dir={{ sort_dir }}&per_page={{ per_page }}"
            class="stat-card stat-card-link {% if status_filter == status_val %}stat-card-active{% endif %}"
-           style="animation-delay: {{ loop.index0 * 0.05 }}s;"
+           data-delay="{{ loop.index0 * 0.05 }}"
            aria-label="Filter by {{ t(label_key) }}">
             <div class="stat-number">{{ count }}</div>
             <span class="badge {{ cls }}">{{ t(label_key) }}</span>
@@ -135,7 +160,7 @@
 
                 {# Per-page selector #}
                 <div class="per-page-wrap">
-                    <select class="per-page-select" onchange="goPerPage(this.value)" aria-label="{{ t('admin.filter.per_page') }}">
+                    <select class="per-page-select" id="dash-per-page-select" aria-label="{{ t('admin.filter.per_page') }}">
                         {% for opt in per_page_options %}
                         <option value="{{ opt }}" {% if per_page == opt %}selected{% endif %}>{{ opt }}</option>
                         {% endfor %}
@@ -182,25 +207,25 @@
                         {% set fb_sla_class = 'sla-ok' if days_to_fb > 14 else ('sla-warning' if days_to_fb > 0 else 'sla-overdue') %}
                     {% endif %}
                     <tr>
-                        <td><span class="mono" style="white-space:nowrap;">{{ report.case_number }}</span></td>
-                        <td style="font-size:0.85rem;color:var(--body-text);">{{ report.category | replace('_', ' ') | title }}</td>
+                        <td><span class="mono dash-nowrap">{{ report.case_number }}</span></td>
+                        <td class="dash-category-cell">{{ report.category | replace('_', ' ') | title }}</td>
                         <td><span class="badge badge-{{ report.status.value }}">{{ t('status.label.' + report.status.value) }}</span></td>
-                        <td class="mono" style="font-size:0.78rem;color:var(--muted);">{{ report.submitted_at.strftime('%Y-%m-%d') }}</td>
-                        <td style="font-size:0.82rem;color:var(--muted);">
+                        <td class="mono dash-date-cell">{{ report.submitted_at.strftime('%Y-%m-%d') }}</td>
+                        <td class="dash-assignee-cell">
                             {% if report.assigned_to %}
-                                <span style="color:var(--body-text);">{{ report.assigned_to.username }}</span>
+                                <span class="dash-assignee-name">{{ report.assigned_to.username }}</span>
                             {% else %}
                                 N/A
                             {% endif %}
                         </td>
-                        <td class="{{ ack_sla_class }}" style="font-size:0.82rem;">
+                        <td class="{{ ack_sla_class }} dash-sla-cell">
                             {% if report.acknowledged_at %}
                                 {{ t('admin.sla.done') }}
                             {% else %}
                                 {{ t('admin.report.sla.day') }} {{ days_since_submit }}/7
                             {% endif %}
                         </td>
-                        <td class="{{ fb_sla_class }}" style="font-size:0.82rem;">
+                        <td class="{{ fb_sla_class }} dash-sla-cell">
                             {% if report.feedback_due_at %}
                                 {% set days_to_fb = (report.feedback_due_at - now).days %}
                                 {% if days_to_fb > 0 %}{{ days_to_fb }} {{ t('admin.report.sla.days_remaining') }}{% else %}{{ t('admin.report.sla.overdue') }}{% endif %}
@@ -263,30 +288,45 @@
 
         {% elif status_filter or my_cases %}
         {# Filtered empty state #}
-        <div style="text-align:center;padding:3rem 1rem;">
-            <div style="font-size:2.5rem;margin-bottom:1rem;opacity:0.3;">&#128269;</div>
-            <p style="font-size:1rem;font-weight:600;color:var(--body-text);margin-bottom:0.4rem;">{{ t('admin.filter.no_results') }}</p>
-            <a href="/admin/dashboard" class="btn btn-secondary btn-sm" style="margin-top:1rem;">{{ t('admin.filter.all_statuses') }}</a>
+        <div class="dash-empty-wrap">
+            <div class="dash-empty-icon">&#128269;</div>
+            <p class="dash-empty-title">{{ t('admin.filter.no_results') }}</p>
+            <a href="/admin/dashboard" class="btn btn-secondary btn-sm dash-mt-btn">{{ t('admin.filter.all_statuses') }}</a>
         </div>
 
         {% else %}
         {# Truly empty - no reports at all #}
-        <div style="text-align:center;padding:3.5rem 1rem;">
-            <div style="font-size:2.5rem;margin-bottom:1rem;opacity:0.3;">&#128274;</div>
-            <p style="font-size:1rem;font-weight:600;color:var(--body-text);margin-bottom:0.4rem;">{{ t('admin.empty.title') }}</p>
-            <p style="font-size:0.85rem;color:var(--muted);">{{ t('admin.empty.body') }}</p>
-            <a href="/submit" class="btn btn-secondary btn-sm" style="margin-top:1.25rem;">{{ t('admin.view_submit') }}</a>
+        <div class="dash-empty-wrap-lg">
+            <div class="dash-empty-icon">&#128274;</div>
+            <p class="dash-empty-title">{{ t('admin.empty.title') }}</p>
+            <p class="dash-empty-body">{{ t('admin.empty.body') }}</p>
+            <a href="/submit" class="btn btn-secondary btn-sm dash-mt-btn-lg">{{ t('admin.view_submit') }}</a>
         </div>
         {% endif %}
     </div>
 </div>
+{% endblock %}
 
-<script>
+{% block scripts %}
+<script nonce="{{ request.state.csp_nonce }}">
 function goPerPage(val) {
     const u = new URL(window.location.href);
     u.searchParams.set('per_page', val);
     u.searchParams.set('page', '1');
     window.location.href = u.toString();
 }
+
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.stat-card-link[data-delay]').forEach(function (el) {
+        el.style.animationDelay = el.dataset.delay + 's';
+    });
+
+    var perPageSelect = document.getElementById('dash-per-page-select');
+    if (perPageSelect) {
+        perPageSelect.addEventListener('change', function () {
+            goPerPage(this.value);
+        });
+    }
+});
 </script>
 {% endblock %}

--- a/app/templates/admin/locations.html
+++ b/app/templates/admin/locations.html
@@ -2,6 +2,18 @@
 
 {% block title %}{{ t('admin.locations.title') }} | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.loc-grid { display:grid;grid-template-columns:1fr 2fr;gap:1.25rem;align-items:start; }
+.loc-row-inactive { opacity:0.5; }
+.loc-name { font-weight:600; }
+.loc-code { font-size:0.82rem; }
+.loc-desc { font-size:0.85rem;color:var(--muted); }
+.loc-inline-form { display:inline; }
+.loc-empty { color:var(--muted);padding:1rem 0; }
+</style>
+{% endblock %}
+
 {% block nav_links %}
 <li><a href="/admin/dashboard">{{ t('admin.dashboard.title') }}</a></li>
 <li><a href="/admin/stats">{{ t('admin.nav.stats') }}</a></li>
@@ -22,7 +34,7 @@
         <h1>{{ t('admin.locations.title') }}</h1>
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 2fr;gap:1.25rem;align-items:start;">
+    <div class="loc-grid">
 
         <div class="panel">
             <div class="panel-header">{{ t('admin.locations.add.header') }}</div>
@@ -74,10 +86,10 @@
                     </thead>
                     <tbody>
                         {% for loc in locations %}
-                        <tr style="{% if not loc.is_active %}opacity:0.5;{% endif %}">
-                            <td style="font-weight:600;">{{ loc.name }}</td>
-                            <td class="mono" style="font-size:0.82rem;">{{ loc.code }}</td>
-                            <td style="font-size:0.85rem;color:var(--muted);">{{ loc.description or '' }}</td>
+                        <tr class="{% if not loc.is_active %}loc-row-inactive{% endif %}">
+                            <td class="loc-name">{{ loc.name }}</td>
+                            <td class="mono loc-code">{{ loc.code }}</td>
+                            <td class="loc-desc">{{ loc.description or '' }}</td>
                             <td>
                                 {% if loc.is_active %}
                                 <span class="badge badge-closed">{{ t('admin.locations.active') }}</span>
@@ -87,12 +99,12 @@
                             </td>
                             <td>
                                 {% if loc.is_active %}
-                                <form method="post" action="/admin/locations/{{ loc.id }}/deactivate" style="display:inline;">
+                                <form method="post" action="/admin/locations/{{ loc.id }}/deactivate" class="loc-inline-form">
                                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                                     <button type="submit" class="btn btn-secondary btn-sm">{{ t('admin.locations.deactivate') }}</button>
                                 </form>
                                 {% else %}
-                                <form method="post" action="/admin/locations/{{ loc.id }}/reactivate" style="display:inline;">
+                                <form method="post" action="/admin/locations/{{ loc.id }}/reactivate" class="loc-inline-form">
                                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                                     <button type="submit" class="btn btn-secondary btn-sm">{{ t('admin.locations.reactivate') }}</button>
                                 </form>
@@ -104,7 +116,7 @@
                 </table>
             </div>
             {% else %}
-            <p style="color:var(--muted);padding:1rem 0;">{{ t('admin.locations.empty') }}</p>
+            <p class="loc-empty">{{ t('admin.locations.empty') }}</p>
             {% endif %}
         </div>
 

--- a/app/templates/admin/organisations.html
+++ b/app/templates/admin/organisations.html
@@ -80,10 +80,10 @@
                         {% if org.slug != 'default' and org.is_active %}
                         <form method="post"
                               action="/admin/organisations/{{ org.id }}/deactivate"
-                              style="display:inline">
+                              style="display:inline"
+                              data-confirm="Deactivate {{ org.name }}?">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                            <button type="submit" class="btn btn--danger btn--sm"
-                                    onclick="return confirm('Deactivate {{ org.name }}?')">
+                            <button type="submit" class="btn btn--danger btn--sm">
                                 Deactivate
                             </button>
                         </form>

--- a/app/templates/admin/organisations.html
+++ b/app/templates/admin/organisations.html
@@ -2,6 +2,12 @@
 
 {% block title %}Organisations | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.org-inline-form { display:inline; }
+</style>
+{% endblock %}
+
 {% block nav_links %}
 <li><a href="/admin/dashboard">{{ t('admin.dashboard.title') }}</a></li>
 <li><a href="/admin/stats">{{ t('admin.nav.stats') }}</a></li>
@@ -80,7 +86,7 @@
                         {% if org.slug != 'default' and org.is_active %}
                         <form method="post"
                               action="/admin/organisations/{{ org.id }}/deactivate"
-                              style="display:inline"
+                              class="org-inline-form"
                               data-confirm="Deactivate {{ org.name }}?">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                             <button type="submit" class="btn btn--danger btn--sm">

--- a/app/templates/admin/report.html
+++ b/app/templates/admin/report.html
@@ -1,5 +1,71 @@
 {% extends "base.html" %}
 
+{% block styles %}<style nonce="{{ request.state.csp_nonce }}">
+.rpt-1 { display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.75rem; }
+.rpt-2 { font-size:0.78rem;color:var(--muted); }
+.rpt-3 { margin-left:auto; }
+.rpt-4 { font-family:var(--font-mono);font-size:clamp(1.1rem,3vw,1.75rem);letter-spacing:0.04em;font-weight:400; }
+.rpt-5 { display:grid;grid-template-columns:2fr 1fr;gap:1.25rem;align-items:start; }
+.rpt-6 { white-space:pre-wrap;font-size:0.95rem;color:var(--body-text);line-height:1.7; }
+.rpt-delay-05 { animation-delay:0.05s; }
+.rpt-7 { margin-bottom:1.5rem; }
+.rpt-8 { color:var(--muted);margin-bottom:1.5rem;font-size:0.88rem; }
+.rpt-delay-08 { animation-delay:0.08s; }
+.rpt-9 { margin-left:0.5rem;font-size:0.7rem;padding:0.15rem 0.5rem;background:var(--warning-subtle);color:var(--warning);border-radius:4px;font-weight:600;letter-spacing:0.05em; }
+.rpt-10 { display:flex;flex-direction:column;gap:0.75rem;margin-bottom:1.25rem; }
+.rpt-11 { padding:0.6rem 0.75rem;background:var(--warning-subtle);border-radius:var(--radius-card); }
+.rpt-12 { font-size:0.75rem;color:var(--muted);margin-bottom:0.25rem; }
+.rpt-13 { color:var(--body-text); }
+.rpt-14 { font-size:0.88rem;white-space:pre-wrap;color:var(--body-text); }
+.rpt-15 { color:var(--muted);margin-bottom:1rem;font-size:0.88rem; }
+.rpt-delay-1 { animation-delay:0.1s; }
+.rpt-16 { list-style:none;padding:0;margin:0 0 1rem;display:flex;flex-direction:column;gap:0.5rem; }
+.rpt-17 { display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0.75rem;background:var(--bg-code);border-radius:6px; }
+.rpt-18 { font-size:0.85rem;font-weight:600; }
+.rpt-19 { font-size:0.7rem; }
+.rpt-20 { font-size:0.8rem;color:var(--muted);flex:1; }
+.rpt-21 { margin:0; }
+.rpt-22 { font-size:0.75rem;padding:0.2rem 0.5rem; }
+.rpt-23 { display:flex;gap:0.5rem;align-items:flex-start; }
+.rpt-24 { flex:1; }
+.rpt-25 { white-space:nowrap; }
+.rpt-delay-12 { animation-delay:0.12s; }
+.rpt-26 { display:flex;flex-direction:column;gap:0.4rem; }
+.rpt-27 { display:flex;gap:0.75rem;align-items:baseline;padding:0.35rem 0;border-bottom:1px solid var(--hairline);font-size:0.8rem; }
+.rpt-28 { color:var(--muted);white-space:nowrap;flex-shrink:0; }
+.rpt-29 { color:var(--body-text);font-weight:600;flex-shrink:0; }
+.rpt-30 { color:var(--accent);font-family:var(--font-mono);font-size:0.75rem; }
+.rpt-31 { color:var(--muted);font-size:0.75rem;font-family:var(--font-mono); }
+.rpt-32 { margin-top:0.75rem; }
+.rpt-33 { font-size:0.78rem; }
+.rpt-34 { color:var(--muted);font-size:0.88rem; }
+.rpt-35 { display:flex;flex-direction:column;gap:1rem;font-size:0.875rem; }
+.rpt-36 { font-size:0.82rem; }
+.rpt-37 { font-size:0.85rem; }
+.rpt-38 { font-size:0.75rem;color:var(--muted);margin-left:0.4rem; }
+.rpt-39 { padding:0.75rem;background:var(--accent-subtle);border:1px solid var(--border-strong);border-radius:var(--radius-sm); }
+.rpt-40 { margin-bottom:0.5rem; }
+.rpt-41 { margin-bottom:0.4rem; }
+.rpt-42 { font-size:0.75rem;color:var(--muted);display:block; }
+.rpt-43 { font-size:0.88rem;font-weight:600; }
+.rpt-44 { font-size:0.88rem; }
+.rpt-45 { margin-top:0.4rem; }
+.rpt-46 { font-size:0.75rem;color:var(--muted); }
+.rpt-47 { font-size:0.8rem;color:var(--muted);font-style:italic; }
+.rpt-delay-04 { animation-delay:0.04s; }
+.rpt-48 { font-size:0.85rem;margin-bottom:1rem; }
+.rpt-delay-06 { animation-delay:0.06s; }
+.rpt-49 { font-size:0.85rem;color:var(--muted); }
+.rpt-delay-1-danger { animation-delay:0.1s;border-color:var(--danger); }
+.rpt-51 { color:var(--danger); }
+.rpt-52 { margin-bottom:1rem; }
+.rpt-53 { font-size:0.75rem;margin-top:0.4rem; }
+.rpt-54 { font-size:0.82rem;color:var(--muted);margin-bottom:0.75rem; }
+.rpt-hidden { display:none; }
+.rpt-55 { display:flex;gap:0.5rem; }
+.rpt-56 { flex:1; }
+</style>{% endblock %}
+
 {% block title %}{{ t('admin.report.eyebrow') }} {{ report.case_number }} | OpenWhistle{% endblock %}
 
 {% block nav_links %}
@@ -18,23 +84,23 @@
 {% block content %}
 <div class="container">
     <div class="page-header">
-        <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.75rem;">
+        <div class="rpt-1">
             <a href="/admin/dashboard" class="btn btn-secondary btn-sm">{{ t('admin.back_dashboard') }}</a>
             <span class="badge badge-{{ report.status.value }}">{{ t('status.label.' + report.status.value) }}</span>
             {% if report.assigned_to %}
-            <span style="font-size:0.78rem;color:var(--muted);">&#128100; {{ report.assigned_to.username }}</span>
+            <span class="rpt-2">&#128100; {{ report.assigned_to.username }}</span>
             {% endif %}
-            <a href="/admin/reports/{{ report.id }}/export.pdf" class="btn btn-secondary btn-sm" style="margin-left:auto;" download>
+            <a href="/admin/reports/{{ report.id }}/export.pdf" class="btn btn-secondary btn-sm rpt-3" download>
                 &#128196; {{ t('admin.report.export_pdf') }}
             </a>
         </div>
         <div class="page-eyebrow">{{ t('admin.report.eyebrow') }}</div>
-        <h1 style="font-family:var(--font-mono);font-size:clamp(1.1rem,3vw,1.75rem);letter-spacing:0.04em;font-weight:400;">
+        <h1 class="rpt-4">
             {{ report.case_number }}
         </h1>
     </div>
 
-    <div style="display:grid;grid-template-columns:2fr 1fr;gap:1.25rem;align-items:start;">
+    <div class="rpt-5">
 
         {# ── Left column: report + thread + reply + notes + links ── #}
         <div>
@@ -46,15 +112,15 @@
                     &nbsp;&nbsp;
                     <span class="badge badge-received">{{ report.category | replace('_', ' ') | title }}</span>
                 </div>
-                <p style="white-space:pre-wrap;font-size:0.95rem;color:var(--body-text);line-height:1.7;">{{ decrypted_description }}</p>
+                <p class="rpt-6">{{ decrypted_description }}</p>
             </div>
 
             {# Communication thread + reply #}
-            <div class="panel" style="animation-delay:0.05s;">
+            <div class="panel rpt-delay-05">
                 <div class="panel-header">{{ t('admin.report.thread') }}</div>
 
                 {% if report.messages %}
-                <div class="thread" style="margin-bottom:1.5rem;">
+                <div class="thread rpt-7">
                     {% for msg in report.messages %}
                     <div class="message message-{{ msg.sender.value }}">
                         <div class="message-meta">
@@ -67,7 +133,7 @@
                     {% endfor %}
                 </div>
                 {% else %}
-                <p style="color:var(--muted);margin-bottom:1.5rem;font-size:0.88rem;">{{ t('admin.report.no_messages') }}</p>
+                <p class="rpt-8">{{ t('admin.report.no_messages') }}</p>
                 {% endif %}
 
                 {% if report.status.value != 'closed' %}
@@ -91,26 +157,26 @@
             </div>
 
             {# Internal notes (admin-only) #}
-            <div class="panel" id="notes" style="animation-delay:0.08s;">
+            <div class="panel rpt-delay-08" id="notes">
                 <div class="panel-header">
                     {{ t('admin.report.notes.header') }}
-                    <span style="margin-left:0.5rem;font-size:0.7rem;padding:0.15rem 0.5rem;background:var(--warning-subtle);color:var(--warning);border-radius:4px;font-weight:600;letter-spacing:0.05em;">{{ t('admin.report.internal_badge') }}</span>
+                    <span class="rpt-9">{{ t('admin.report.internal_badge') }}</span>
                 </div>
 
                 {% if report.notes %}
-                <div style="display:flex;flex-direction:column;gap:0.75rem;margin-bottom:1.25rem;">
+                <div class="rpt-10">
                     {% for note in report.notes %}
-                    <div style="padding:0.6rem 0.75rem;background:var(--warning-subtle);border-radius:var(--radius-card)">
-                        <div style="font-size:0.75rem;color:var(--muted);margin-bottom:0.25rem;">
-                            <strong style="color:var(--body-text);">{{ note.author_username }}</strong>
+                    <div class="rpt-11">
+                        <div class="rpt-12">
+                            <strong class="rpt-13">{{ note.author_username }}</strong>
                             &middot; <span class="mono"><time data-utc="{{ note.created_at.isoformat() }}">{{ note.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                         </div>
-                        <div style="font-size:0.88rem;white-space:pre-wrap;color:var(--body-text);">{{ note.content }}</div>
+                        <div class="rpt-14">{{ note.content }}</div>
                     </div>
                     {% endfor %}
                 </div>
                 {% else %}
-                <p style="color:var(--muted);margin-bottom:1rem;font-size:0.88rem;">{{ t('admin.report.notes.none') }}</p>
+                <p class="rpt-15">{{ t('admin.report.notes.none') }}</p>
                 {% endif %}
 
                 <form method="post" action="/admin/reports/{{ report.id }}/notes">
@@ -126,21 +192,19 @@
             </div>
 
             {# Linked cases #}
-            <div class="panel" id="links" style="animation-delay:0.1s;">
+            <div class="panel rpt-delay-1" id="links">
                 <div class="panel-header">{{ t('admin.report.links.header') }}</div>
 
                 {% if linked_reports %}
-                <ul style="list-style:none;padding:0;margin:0 0 1rem;display:flex;flex-direction:column;gap:0.5rem;">
+                <ul class="rpt-16">
                     {% for lr in linked_reports %}
-                    <li style="display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0.75rem;background:var(--bg-code);border-radius:6px;">
-                        <a href="/admin/reports/{{ lr.id }}" class="mono" style="font-size:0.85rem;font-weight:600;">{{ lr.case_number }}</a>
-                        <span class="badge badge-{{ lr.status }}" style="font-size:0.7rem;">{{ t('status.label.' + lr.status) }}</span>
-                        <span style="font-size:0.8rem;color:var(--muted);flex:1;">{{ lr.category | replace('_', ' ') | title }}</span>
-                        <form method="post" action="/admin/reports/{{ report.id }}/links/{{ lr.link_id }}/delete" style="margin:0;">
+                    <li class="rpt-17">
+                        <a href="/admin/reports/{{ lr.id }}" class="mono rpt-18">{{ lr.case_number }}</a>
+                        <span class="badge badge-{{ lr.status }} rpt-19">{{ t('status.label.' + lr.status) }}</span>
+                        <span class="rpt-20">{{ lr.category | replace('_', ' ') | title }}</span>
+                        <form method="post" action="/admin/reports/{{ report.id }}/links/{{ lr.link_id }}/delete" class="rpt-21" data-confirm="Remove link with {{ lr.case_number }}?">
                             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                            <button type="submit" class="btn btn-secondary btn-sm"
-                                onclick="return confirm('Remove link with {{ lr.case_number }}?')"
-                                style="font-size:0.75rem;padding:0.2rem 0.5rem;">
+                            <button type="submit" class="btn btn-secondary btn-sm rpt-22">
                                 {{ t('admin.report.links.remove') }}
                             </button>
                         </form>
@@ -148,40 +212,40 @@
                     {% endfor %}
                 </ul>
                 {% else %}
-                <p style="color:var(--muted);margin-bottom:1rem;font-size:0.88rem;">{{ t('admin.report.links.none') }}</p>
+                <p class="rpt-15">{{ t('admin.report.links.none') }}</p>
                 {% endif %}
 
-                <form method="post" action="/admin/reports/{{ report.id }}/links" style="display:flex;gap:0.5rem;align-items:flex-start;">
+                <form method="post" action="/admin/reports/{{ report.id }}/links" class="rpt-23">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                    <input type="text" class="form-control" name="case_number" style="flex:1;"
+                    <input type="text" class="form-control rpt-24" name="case_number"
                         placeholder="{{ t('admin.report.links.placeholder') }}"
                         pattern="OW-\d{4}-\d{5}" title="Format: OW-YYYY-NNNNN"
                         required>
-                    <button type="submit" class="btn btn-secondary btn-sm" style="white-space:nowrap;">{{ t('admin.report.links.button') }}</button>
+                    <button type="submit" class="btn btn-secondary btn-sm rpt-25">{{ t('admin.report.links.button') }}</button>
                 </form>
             </div>
 
             {# Audit log timeline #}
-            <div class="panel" id="audit" style="animation-delay:0.12s;">
+            <div class="panel rpt-delay-12" id="audit">
                 <div class="panel-header">{{ t('admin.report.audit.header') }}</div>
                 {% if audit_entries %}
-                <div style="display:flex;flex-direction:column;gap:0.4rem;">
+                <div class="rpt-26">
                     {% for entry in audit_entries %}
-                    <div style="display:flex;gap:0.75rem;align-items:baseline;padding:0.35rem 0;border-bottom:1px solid var(--hairline);font-size:0.8rem;">
-                        <span class="mono" style="color:var(--muted);white-space:nowrap;flex-shrink:0;"><time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%m-%d %H:%M') }}</time></span>
-                        <span style="color:var(--body-text);font-weight:600;flex-shrink:0;">{{ entry.admin_username or 'N/A' }}</span>
-                        <span style="color:var(--accent);font-family:var(--font-mono);font-size:0.75rem;">{{ entry.action }}</span>
+                    <div class="rpt-27">
+                        <span class="mono rpt-28"><time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%m-%d %H:%M') }}</time></span>
+                        <span class="rpt-29">{{ entry.admin_username or 'N/A' }}</span>
+                        <span class="rpt-30">{{ entry.action }}</span>
                         {% if entry.detail %}
-                        <span style="color:var(--muted);font-size:0.75rem;font-family:var(--font-mono);">{{ entry.detail[:80] }}</span>
+                        <span class="rpt-31">{{ entry.detail[:80] }}</span>
                         {% endif %}
                     </div>
                     {% endfor %}
                 </div>
-                <div style="margin-top:0.75rem;">
-                    <a href="/admin/audit-log?report_id={{ report.id }}" class="btn btn-secondary btn-sm" style="font-size:0.78rem;">{{ t('admin.report.audit.full_trail') }}</a>
+                <div class="rpt-32">
+                    <a href="/admin/audit-log?report_id={{ report.id }}" class="btn btn-secondary btn-sm rpt-33">{{ t('admin.report.audit.full_trail') }}</a>
                 </div>
                 {% else %}
-                <p style="color:var(--muted);font-size:0.88rem;">{{ t('admin.report.audit.none') }}</p>
+                <p class="rpt-34">{{ t('admin.report.audit.none') }}</p>
                 {% endif %}
             </div>
 
@@ -194,15 +258,15 @@
             <div class="panel">
                 <div class="panel-header">{{ t('admin.report.details') }}</div>
 
-                <div style="display:flex;flex-direction:column;gap:1rem;font-size:0.875rem;">
+                <div class="rpt-35">
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.submitted') }}</div>
-                        <span class="mono" style="font-size:0.82rem;"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
+                        <span class="mono rpt-36"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                     </div>
 
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.mode') }}</div>
-                        <span style="font-size:0.85rem;">
+                        <span class="rpt-37">
                             {% if report.submission_mode.value == 'confidential' %}
                             <span class="badge badge-in_review">{{ t('submit.step.mode.confidential.label') }}</span>
                             {% else %}
@@ -214,46 +278,46 @@
                     {% if report.location %}
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.location') }}</div>
-                        <span style="font-size:0.85rem;font-weight:600;">{{ report.location.name }}</span>
-                        <span class="mono" style="font-size:0.75rem;color:var(--muted);margin-left:0.4rem;">{{ report.location.code }}</span>
+                        <span class="rpt-18">{{ report.location.name }}</span>
+                        <span class="mono rpt-38">{{ report.location.code }}</span>
                     </div>
                     {% endif %}
 
                     {% if (is_admin or report.assigned_to_id == user.id) and (confidential_name or confidential_contact) %}
-                    <div style="padding:0.75rem;background:var(--accent-subtle);border:1px solid var(--border-strong);border-radius:var(--radius-sm);">
-                        <div class="detail-label" style="margin-bottom:0.5rem;">{{ t('admin.report.confidential.header') }}</div>
+                    <div class="rpt-39">
+                        <div class="detail-label rpt-40">{{ t('admin.report.confidential.header') }}</div>
                         {% if confidential_name %}
-                        <div style="margin-bottom:0.4rem;">
-                            <span style="font-size:0.75rem;color:var(--muted);display:block;">{{ t('admin.report.confidential.name') }}</span>
-                            <span style="font-size:0.88rem;font-weight:600;">{{ confidential_name }}</span>
+                        <div class="rpt-41">
+                            <span class="rpt-42">{{ t('admin.report.confidential.name') }}</span>
+                            <span class="rpt-43">{{ confidential_name }}</span>
                         </div>
                         {% endif %}
                         {% if confidential_contact %}
                         <div>
-                            <span style="font-size:0.75rem;color:var(--muted);display:block;">{{ t('admin.report.confidential.contact') }}</span>
-                            <span style="font-size:0.88rem;">{{ confidential_contact }}</span>
+                            <span class="rpt-42">{{ t('admin.report.confidential.contact') }}</span>
+                            <span class="rpt-44">{{ confidential_contact }}</span>
                         </div>
                         {% endif %}
                         {% if has_secure_email %}
-                        <div style="margin-top:0.4rem;">
-                            <span style="font-size:0.75rem;color:var(--muted);">{{ t('admin.report.confidential.secure_email_set') }}</span>
+                        <div class="rpt-45">
+                            <span class="rpt-46">{{ t('admin.report.confidential.secure_email_set') }}</span>
                         </div>
                         {% endif %}
                     </div>
                     {% elif has_secure_email %}
                     <div>
                         <div class="detail-label">{{ t('admin.report.confidential.secure_email_set') }}</div>
-                        <span style="font-size:0.8rem;color:var(--muted);font-style:italic;">{{ t('admin.report.confidential.email_note') }}</span>
+                        <span class="rpt-47">{{ t('admin.report.confidential.email_note') }}</span>
                     </div>
                     {% endif %}
 
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.sla7') }}</div>
                         {% if report.acknowledged_at %}
-                            <span class="sla-ok mono" style="font-size:0.82rem;">&#10003; {{ report.acknowledged_at.strftime('%Y-%m-%d') }}</span>
+                            <span class="sla-ok mono rpt-36">&#10003; {{ report.acknowledged_at.strftime('%Y-%m-%d') }}</span>
                         {% else %}
                             {% set days = (now - report.submitted_at).days %}
-                            <span class="{{ 'sla-overdue' if days >= 7 else ('sla-warning' if days >= 5 else 'sla-ok') }} mono" style="font-size:0.82rem;">
+                            <span class="{{ 'sla-overdue' if days >= 7 else ('sla-warning' if days >= 5 else 'sla-ok') }} mono rpt-36">
                                 {{ t('admin.report.sla.day') }} {{ days }}/7: {{ t('admin.report.sla.not_ack') }}
                             </span>
                         {% endif %}
@@ -263,7 +327,7 @@
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.sla3m') }}</div>
                         {% set days_left = (report.feedback_due_at - now).days %}
-                        <span class="{{ 'sla-overdue' if days_left < 0 else ('sla-warning' if days_left < 14 else 'sla-ok') }} mono" style="font-size:0.82rem;">
+                        <span class="{{ 'sla-overdue' if days_left < 0 else ('sla-warning' if days_left < 14 else 'sla-ok') }} mono rpt-36">
                             {{ report.feedback_due_at.strftime('%Y-%m-%d') }}
                             {% if days_left >= 0 %}({{ days_left }} {{ t('admin.report.sla.days_remaining') }}){% else %}({{ t('admin.report.sla.overdue') }}){% endif %}
                         </span>
@@ -274,7 +338,7 @@
 
             {# Attachments #}
             {% if report.attachments %}
-            <div class="panel" style="animation-delay:0.04s;">
+            <div class="panel rpt-delay-04">
                 <div class="panel-header">{{ t('admin.report.attachments.header') }}</div>
                 <ul class="attachment-items">
                     {% for att in report.attachments %}
@@ -293,9 +357,9 @@
 
             {# Acknowledge action #}
             {% if not report.acknowledged_at %}
-            <div class="panel" style="animation-delay:0.05s;">
+            <div class="panel rpt-delay-05">
                 <div class="panel-header">{{ t('admin.report.ack.header') }}</div>
-                <p style="font-size:0.85rem;margin-bottom:1rem;">{{ t('admin.report.ack.body') }}</p>
+                <p class="rpt-48">{{ t('admin.report.ack.body') }}</p>
                 <form method="post" action="/admin/reports/{{ report.id }}/acknowledge">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                     <button type="submit" class="btn btn-primary btn-block">
@@ -307,7 +371,7 @@
 
             {# Case assignment (admin only) #}
             {% if is_admin %}
-            <div class="panel" style="animation-delay:0.06s;">
+            <div class="panel rpt-delay-06">
                 <div class="panel-header">{{ t('admin.report.assign.header') }}</div>
                 <form method="post" action="/admin/reports/{{ report.id }}/assign">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
@@ -330,10 +394,10 @@
             {% endif %}
 
             {# Status update - only valid transitions #}
-            <div class="panel" style="animation-delay:0.08s;">
+            <div class="panel rpt-delay-08">
                 <div class="panel-header">{{ t('admin.report.status.header') }}</div>
                 {% if allowed_transitions %}
-                <form method="post" action="/admin/reports/{{ report.id }}/status">
+                <form method="post" action="/admin/reports/{{ report.id }}/status" id="status-form">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                     <div class="form-group">
                         <label class="form-label" for="new-status">{{ t('admin.report.status.label') }}</label>
@@ -344,32 +408,31 @@
                             {% endfor %}
                         </select>
                     </div>
-                    <button type="submit" id="status-btn" class="btn btn-secondary btn-block"
-                        onclick="return confirmStatusChange(this.form.new_status.value, '{{ report.status.value }}')">
+                    <button type="submit" id="status-btn" class="btn btn-secondary btn-block">
                         {{ t('admin.report.status.button') }}
                     </button>
                 </form>
                 {% else %}
-                <p style="font-size:0.85rem;color:var(--muted);">No further status transitions available.</p>
+                <p class="rpt-49">No further status transitions available.</p>
                 {% endif %}
             </div>
 
             {# 4-eyes deletion (admin only) #}
             {% if is_admin %}
-            <div class="panel" style="animation-delay:0.1s;border-color:var(--danger);">
-                <div class="panel-header" style="color:var(--danger);">{{ t('admin.report.delete.header') }}</div>
+            <div class="panel rpt-delay-1-danger">
+                <div class="panel-header rpt-51">{{ t('admin.report.delete.header') }}</div>
 
                 {% if report.deletion_request %}
                     {# Pending deletion request exists #}
-                    <div class="alert alert-error" style="margin-bottom:1rem;">
+                    <div class="alert alert-error rpt-52">
                         <div class="alert-title">{{ t('admin.report.delete.pending.title') }}</div>
                         {{ t('admin.report.delete.pending.body', username=report.deletion_request.requested_by_username) }}
-                        <div class="mono" style="font-size:0.75rem;margin-top:0.4rem;"><time data-utc="{{ report.deletion_request.requested_at.isoformat() }}">{{ report.deletion_request.requested_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></div>
+                        <div class="mono rpt-53"><time data-utc="{{ report.deletion_request.requested_at.isoformat() }}">{{ report.deletion_request.requested_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></div>
                     </div>
 
                     {% if report.deletion_request.requested_by_id == user.id %}
                     {# Current user requested - can only cancel #}
-                    <p style="font-size:0.82rem;color:var(--muted);margin-bottom:0.75rem;">{{ t('admin.report.delete.cannot_self') }}</p>
+                    <p class="rpt-54">{{ t('admin.report.delete.cannot_self') }}</p>
                     <form method="post" action="/admin/reports/{{ report.id }}/cancel-delete">
                         <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                         <button type="submit" class="btn btn-secondary btn-block">{{ t('admin.report.delete.cancel_request') }}</button>
@@ -377,7 +440,7 @@
                     {% else %}
                     {# Different admin - can confirm #}
                     <form method="post" action="/admin/reports/{{ report.id }}/confirm-delete"
-                          onsubmit="return confirm('Permanently delete this report? This cannot be undone.')">
+                          data-confirm="Permanently delete this report? This cannot be undone.">
                         <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                         <button type="submit" class="btn btn-danger btn-block">{{ t('admin.report.delete.confirm_4eyes') }}</button>
                     </form>
@@ -385,27 +448,24 @@
 
                 {% else %}
                     {# No pending request - show request button #}
-                    <p style="font-size:0.85rem;margin-bottom:1rem;">{{ t('admin.report.delete.body') }}</p>
+                    <p class="rpt-48">{{ t('admin.report.delete.body') }}</p>
                     <div id="delete-step-1">
-                        <button type="button" class="btn btn-secondary btn-block"
-                            onclick="document.getElementById('delete-step-1').style.display='none';document.getElementById('delete-step-2').style.display='block';">
+                        <button type="button" id="delete-step-1-btn" class="btn btn-secondary btn-block">
                             {{ t('admin.report.delete.request') }}
                         </button>
                     </div>
-                    <div id="delete-step-2" style="display:none;">
-                        <div class="alert alert-error" style="margin-bottom:1rem;">
+                    <div id="delete-step-2" class="rpt-hidden">
+                        <div class="alert alert-error rpt-52">
                             <div class="alert-title">{{ t('admin.report.delete.confirm.title') }}</div>
                             {{ t('admin.report.delete.confirm.body') }}
                         </div>
                         <form method="post" action="/admin/reports/{{ report.id }}/request-delete">
                             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                            <div style="display:flex;gap:0.5rem;">
-                                <button type="button" class="btn btn-secondary"
-                                    style="flex:1"
-                                    onclick="document.getElementById('delete-step-1').style.display='block';document.getElementById('delete-step-2').style.display='none';">
+                            <div class="rpt-55">
+                                <button type="button" id="delete-step-2-cancel-btn" class="btn btn-secondary rpt-56">
                                     {{ t('admin.report.delete.cancel') }}
                                 </button>
-                                <button type="submit" class="btn btn-danger" style="flex:1">
+                                <button type="submit" class="btn btn-danger rpt-56">
                                     {{ t('admin.report.delete.request') }}
                                 </button>
                             </div>
@@ -421,7 +481,7 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
+<script nonce="{{ request.state.csp_nonce }}">
 function confirmStatusChange(newStatus, currentStatus) {
     if (newStatus === currentStatus) return false;
     if (newStatus === 'closed') {
@@ -443,6 +503,34 @@ function confirmStatusChange(newStatus, currentStatus) {
         btn.disabled = false;
         btn.style.opacity = '';
     });
+
+    var form = document.getElementById('status-form');
+    if (form) {
+        form.addEventListener('submit', function(e) {
+            if (!confirmStatusChange(sel.value, '{{ report.status.value }}')) {
+                e.preventDefault();
+            }
+        });
+    }
+})();
+
+(function() {
+    var step1 = document.getElementById('delete-step-1');
+    var step2 = document.getElementById('delete-step-2');
+    var openBtn = document.getElementById('delete-step-1-btn');
+    var cancelBtn = document.getElementById('delete-step-2-cancel-btn');
+    if (openBtn && step1 && step2) {
+        openBtn.addEventListener('click', function() {
+            step1.style.display = 'none';
+            step2.style.display = 'block';
+        });
+    }
+    if (cancelBtn && step1 && step2) {
+        cancelBtn.addEventListener('click', function() {
+            step1.style.display = 'block';
+            step2.style.display = 'none';
+        });
+    }
 })();
 </script>
 {% endblock %}

--- a/app/templates/admin/report.html
+++ b/app/templates/admin/report.html
@@ -219,7 +219,7 @@
                     </div>
                     {% endif %}
 
-                    {% if confidential_name or confidential_contact %}
+                    {% if (is_admin or report.assigned_to_id == user.id) and (confidential_name or confidential_contact) %}
                     <div style="padding:0.75rem;background:var(--accent-subtle);border:1px solid var(--border-strong);border-radius:var(--radius-sm);">
                         <div class="detail-label" style="margin-bottom:0.5rem;">{{ t('admin.report.confidential.header') }}</div>
                         {% if confidential_name %}

--- a/app/templates/admin/stats.html
+++ b/app/templates/admin/stats.html
@@ -1,5 +1,21 @@
 {% extends "base.html" %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.stat-kpi-grid { display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin-bottom:2rem; }
+.stat-kpi-label { font-size:0.8rem;color:var(--muted);margin-top:0.25rem; }
+.stat-two-col { display:grid;grid-template-columns:1fr 1fr;gap:1.25rem; }
+.stat-flex-col-gap { display:flex;flex-direction:column;gap:0.75rem; }
+.stat-row-header { display:flex;justify-content:space-between;margin-bottom:0.25rem; }
+.stat-muted-sm { font-size:0.82rem;color:var(--muted); }
+.stat-muted { color:var(--muted); }
+.stat-cat-label { font-size:0.85rem;color:var(--body-text); }
+.stat-bar-track { height:6px;background:var(--hairline);border-radius:3px;overflow:hidden; }
+.stat-bar-fill { height:100%;background:var(--accent);border-radius:3px;transition:width 0.4s ease; }
+.stat-bar-fill-outline { height:100%;background:var(--accent-subtle);border:1px solid var(--accent);border-radius:3px; }
+</style>
+{% endblock %}
+
 {% block title %}{{ t('admin.stats.title') }} | OpenWhistle{% endblock %}
 
 {% block nav_links %}
@@ -23,16 +39,16 @@
     </div>
 
     {# Top-line KPIs #}
-    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:1rem;margin-bottom:2rem;">
-        <div class="stat-card" style="animation-delay:0s;">
+    <div class="stat-kpi-grid">
+        <div class="stat-card" data-delay="0">
             <div class="stat-number">{{ stats.total_reports }}</div>
-            <div style="font-size:0.8rem;color:var(--muted);margin-top:0.25rem;">{{ t('admin.stats.total_reports') }}</div>
+            <div class="stat-kpi-label">{{ t('admin.stats.total_reports') }}</div>
         </div>
-        <div class="stat-card" style="animation-delay:0.05s;">
-            <div class="stat-number" style="color:{% if stats.sla_7day_rate >= 90 %}var(--success){% elif stats.sla_7day_rate >= 70 %}var(--warning){% else %}var(--danger){% endif %};">
+        <div class="stat-card" data-delay="0.05">
+            <div class="stat-number" data-tone="{{ 'success' if stats.sla_7day_rate >= 90 else ('warning' if stats.sla_7day_rate >= 70 else 'danger') }}">
                 {{ stats.sla_7day_rate }}%
             </div>
-            <div style="font-size:0.8rem;color:var(--muted);margin-top:0.25rem;">{{ t('admin.stats.sla_rate') }}</div>
+            <div class="stat-kpi-label">{{ t('admin.stats.sla_rate') }}</div>
         </div>
         {% for status_val, cls in [
             ('received', 'badge-received'),
@@ -41,20 +57,20 @@
             ('closed', 'badge-closed')
         ] %}
         {% set count = stats.status_counts.get(status_val, 0) %}
-        <div class="stat-card" style="animation-delay:{{ loop.index * 0.05 }}s;">
+        <div class="stat-card" data-delay="{{ loop.index * 0.05 }}">
             <div class="stat-number">{{ count }}</div>
             <span class="badge {{ cls }}">{{ t('status.label.' + status_val) }}</span>
         </div>
         {% endfor %}
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.25rem;">
+    <div class="stat-two-col">
 
         {# By status #}
         <div class="panel">
             <div class="panel-header">{{ t('admin.stats.by_status') }}</div>
             {% if stats.total_reports > 0 %}
-            <div style="display:flex;flex-direction:column;gap:0.75rem;">
+            <div class="stat-flex-col-gap">
                 {% for sv, cls, label_key in [
                     ('received',         'badge-received',         'status.label.received'),
                     ('in_review',        'badge-in_review',        'status.label.in_review'),
@@ -64,18 +80,18 @@
                 {% set count = stats.status_counts.get(sv, 0) %}
                 {% set pct = (count / stats.total_reports * 100) | round(1) %}
                 <div>
-                    <div style="display:flex;justify-content:space-between;margin-bottom:0.25rem;">
+                    <div class="stat-row-header">
                         <span class="badge {{ cls }}">{{ t(label_key) }}</span>
-                        <span style="font-size:0.82rem;color:var(--muted);">{{ count }} ({{ pct }}%)</span>
+                        <span class="stat-muted-sm">{{ count }} ({{ pct }}%)</span>
                     </div>
-                    <div style="height:6px;background:var(--hairline);border-radius:3px;overflow:hidden;">
-                        <div style="height:100%;width:{{ pct }}%;background:var(--accent);border-radius:3px;transition:width 0.4s ease;"></div>
+                    <div class="stat-bar-track">
+                        <div class="stat-bar-fill" data-pct="{{ pct }}"></div>
                     </div>
                 </div>
                 {% endfor %}
             </div>
             {% else %}
-            <p style="color:var(--muted);">No data yet.</p>
+            <p class="stat-muted">No data yet.</p>
             {% endif %}
         </div>
 
@@ -84,25 +100,43 @@
             <div class="panel-header">{{ t('admin.stats.by_category') }}</div>
             {% if stats.by_category %}
             {% set max_cat = stats.by_category.values() | max %}
-            <div style="display:flex;flex-direction:column;gap:0.75rem;">
+            <div class="stat-flex-col-gap">
                 {% for slug, count in stats.by_category.items() | sort(attribute='1', reverse=True) %}
                 {% set pct = (count / stats.total_reports * 100) | round(1) if stats.total_reports else 0 %}
                 <div>
-                    <div style="display:flex;justify-content:space-between;margin-bottom:0.25rem;">
-                        <span style="font-size:0.85rem;color:var(--body-text);">{{ cat_map.get(slug, slug | replace('_', ' ') | title) }}</span>
-                        <span style="font-size:0.82rem;color:var(--muted);">{{ count }} ({{ pct }}%)</span>
+                    <div class="stat-row-header">
+                        <span class="stat-cat-label">{{ cat_map.get(slug, slug | replace('_', ' ') | title) }}</span>
+                        <span class="stat-muted-sm">{{ count }} ({{ pct }}%)</span>
                     </div>
-                    <div style="height:6px;background:var(--hairline);border-radius:3px;overflow:hidden;">
-                        <div style="height:100%;width:{{ (count / max_cat * 100) | round(1) }}%;background:var(--accent-subtle);border:1px solid var(--accent);border-radius:3px;"></div>
+                    <div class="stat-bar-track">
+                        <div class="stat-bar-fill-outline" data-pct="{{ (count / max_cat * 100) | round(1) }}"></div>
                     </div>
                 </div>
                 {% endfor %}
             </div>
             {% else %}
-            <p style="color:var(--muted);">No data yet.</p>
+            <p class="stat-muted">No data yet.</p>
             {% endif %}
         </div>
 
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ request.state.csp_nonce }}">
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-delay]').forEach(function (el) {
+        el.style.animationDelay = el.dataset.delay + 's';
+    });
+
+    document.querySelectorAll('[data-tone]').forEach(function (el) {
+        el.style.color = 'var(--' + el.dataset.tone + ')';
+    });
+
+    document.querySelectorAll('[data-pct]').forEach(function (el) {
+        el.style.width = el.dataset.pct + '%';
+    });
+});
+</script>
 {% endblock %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -108,10 +108,10 @@
                                     {# Activate / Deactivate #}
                                     {% if u.id != user.id %}
                                     {% if u.is_active %}
-                                    <form method="post" action="/admin/users/{{ u.id }}/deactivate">
+                                    <form method="post" action="/admin/users/{{ u.id }}/deactivate"
+                                          data-confirm="Deactivate {{ u.username }}?">
                                         <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                                        <button type="submit" class="btn btn-secondary btn-sm"
-                                            onclick="return confirm('Deactivate {{ u.username }}?')">
+                                        <button type="submit" class="btn btn-secondary btn-sm">
                                             {{ t('admin.users.deactivate') }}
                                         </button>
                                     </form>

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,6 +2,22 @@
 
 {% block title %}{{ t('admin.users.title') }} | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+    .usr-layout { display:grid;grid-template-columns:1fr 2fr;gap:1.25rem;align-items:start; }
+    .usr-note { margin-bottom:1rem;font-size:0.82rem; }
+    .usr-row-inactive { opacity:0.5; }
+    .usr-username { font-weight:600; }
+    .usr-username-self { color:var(--accent); }
+    .usr-you-tag { font-size:0.72rem;color:var(--muted); }
+    .usr-status-badge { font-size:0.7rem; }
+    .usr-actions { display:flex;gap:0.4rem;flex-wrap:wrap; }
+    .usr-role-form { display:flex;gap:0.25rem; }
+    .usr-role-select { font-size:0.78rem;padding:0.2rem 0.4rem;height:auto; }
+    .usr-role-btn { font-size:0.75rem;padding:0.2rem 0.5rem; }
+</style>
+{% endblock %}
+
 {% block nav_links %}
 <li><a href="/admin/dashboard">{{ t('admin.dashboard.title') }}</a></li>
 <li><a href="/admin/stats">{{ t('admin.nav.stats') }}</a></li>
@@ -22,7 +38,7 @@
         <h1>{{ t('admin.users.title') }}</h1>
     </div>
 
-    <div style="display:grid;grid-template-columns:1fr 2fr;gap:1.25rem;align-items:start;">
+    <div class="usr-layout">
 
         {# Add new user form #}
         <div class="panel">
@@ -48,7 +64,7 @@
                         {% endfor %}
                     </select>
                 </div>
-                <div class="alert alert-info" style="margin-bottom:1rem;font-size:0.82rem;">
+                <div class="alert alert-info usr-note">
                     {{ t('admin.users.add.totp_note') }}
                 </div>
                 <button type="submit" class="btn btn-primary btn-block">{{ t('admin.users.add.button') }}</button>
@@ -71,35 +87,35 @@
                     </thead>
                     <tbody>
                         {% for u in users %}
-                        <tr style="{% if not u.is_active %}opacity:0.5;{% endif %}">
+                        <tr class="{% if not u.is_active %}usr-row-inactive{% endif %}">
                             <td>
-                                <span style="font-weight:600;{% if u.id == user.id %}color:var(--accent);{% endif %}">
+                                <span class="usr-username{% if u.id == user.id %} usr-username-self{% endif %}">
                                     {{ u.username }}
                                 </span>
-                                {% if u.id == user.id %}<span style="font-size:0.72rem;color:var(--muted);"> (you)</span>{% endif %}
+                                {% if u.id == user.id %}<span class="usr-you-tag"> (you)</span>{% endif %}
                             </td>
                             <td>
                                 <span class="badge badge-{{ u.role.value }}">{{ t('role.label.' + u.role.value) }}</span>
                             </td>
                             <td>
                                 {% if u.is_active %}
-                                <span class="badge badge-closed" style="font-size:0.7rem;">{{ t('admin.users.active') }}</span>
+                                <span class="badge badge-closed usr-status-badge">{{ t('admin.users.active') }}</span>
                                 {% else %}
-                                <span class="badge" style="font-size:0.7rem;">{{ t('admin.users.inactive') }}</span>
+                                <span class="badge usr-status-badge">{{ t('admin.users.inactive') }}</span>
                                 {% endif %}
                             </td>
                             <td>
-                                <div style="display:flex;gap:0.4rem;flex-wrap:wrap;">
+                                <div class="usr-actions">
                                     {# Role change #}
                                     {% if u.id != user.id %}
-                                    <form method="post" action="/admin/users/{{ u.id }}/role" style="display:flex;gap:0.25rem;">
+                                    <form method="post" action="/admin/users/{{ u.id }}/role" class="usr-role-form">
                                         <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                                        <select name="role" class="form-control" style="font-size:0.78rem;padding:0.2rem 0.4rem;height:auto;">
+                                        <select name="role" class="form-control usr-role-select">
                                             {% for role in roles %}
                                             <option value="{{ role.value }}" {{ 'selected' if u.role == role else '' }}>{{ role.value }}</option>
                                             {% endfor %}
                                         </select>
-                                        <button type="submit" class="btn btn-secondary btn-sm" style="font-size:0.75rem;padding:0.2rem 0.5rem;">
+                                        <button type="submit" class="btn btn-secondary btn-sm usr-role-btn">
                                             {{ t('admin.users.change_role') }}
                                         </button>
                                     </form>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,16 +14,21 @@
     <link rel="stylesheet" href="/static/css/fonts.css">
     <link rel="stylesheet" href="/static/css/site.css">
 
-    {# Inject brand colours as CSS custom properties #}
-    <style>
+    {# Inject brand colours as CSS custom properties + shared base utilities.
+       Nonce'd so it is allowed under the strict CSP (no 'unsafe-inline'). #}
+    <style nonce="{{ request.state.csp_nonce }}">
         :root {
             --brand-primary:   {{ brand.primary_color }};
             --brand-secondary: {{ brand.secondary_color }};
         }
+        .u-hidden { display: none; }
+        .u-m0 { margin: 0; }
+        .u-dim { opacity: 0.4; }
+        .u-caret { font-size: 0.65em; margin-left: 0.2em; }
     </style>
 
     {# Apply theme before page renders to prevent flash #}
-    <script>
+    <script nonce="{{ request.state.csp_nonce }}">
         (function(){
             var t = null;
             try { t = localStorage.getItem('ow-theme'); } catch(e){}
@@ -33,6 +38,7 @@
     </script>
 
     {% block head %}{% endblock %}
+    {% block styles %}{% endblock %}
 </head>
 <body>
     <a href="#main-content" class="skip-link">{{ t('a11y.skip_to_content') }}</a>
@@ -78,12 +84,12 @@
                 <div class="lang-picker" role="navigation" aria-label="{{ t('nav.lang_picker_label') }}">
                     <button type="button" class="lang-picker-btn" aria-haspopup="listbox" aria-expanded="false" id="lang-picker-btn">
                         {{ lang | upper }}
-                        <span aria-hidden="true" style="font-size:0.65em;margin-left:0.2em;">▾</span>
+                        <span aria-hidden="true" class="u-caret">▾</span>
                     </button>
                     <ul class="lang-picker-menu" role="listbox" aria-label="{{ t('nav.lang_picker_label') }}" id="lang-picker-menu" hidden>
                         {% for code, label in [('en', 'English'), ('de', 'Deutsch'), ('fr', 'Français'), ('pt-br', 'Português (BR)')] %}
                         <li role="option" {% if lang == code %}aria-selected="true"{% endif %}>
-                            <form method="post" action="/set-language" style="margin:0;">
+                            <form method="post" action="/set-language" class="u-m0">
                                 <input type="hidden" name="next" value="{{ request.url.path }}{% if request.url.query %}?{{ request.url.query }}{% endif %}">
                                 <input type="hidden" name="lang" value="{{ code }}">
                                 <button type="submit" class="lang-picker-option {{ 'active' if lang == code else '' }}">
@@ -99,7 +105,7 @@
                 <button
                     class="theme-toggle"
                     id="theme-toggle"
-                    onclick="toggleTheme()"
+                    type="button"
                     aria-label="{{ t('nav.toggle_theme') }}"
                     title="{{ t('nav.toggle_theme') }}">
                     ◑
@@ -110,7 +116,7 @@
 
     {% if session_expires_at %}
     <div id="session-expiry-banner"
-         class="session-expiry-banner"
+         class="session-expiry-banner u-hidden"
          data-expires="{{ session_expires_at }}"
          data-text-warning="{{ t('session.expiry.warning') }}"
          data-text-extend="{{ t('session.expiry.extend') }}"
@@ -118,16 +124,15 @@
          data-text-expired-title="{{ t('session.expiry.expired_title') }}"
          data-text-expired-body="{{ t('session.expiry.expired_body') }}"
          role="alert"
-         aria-live="polite"
-         style="display:none;">
+         aria-live="polite">
         <div class="session-expiry-icon" aria-hidden="true">&#9201;</div>
         <div class="session-expiry-body">
             <span class="session-expiry-warning-text">{{ t('session.expiry.warning') }}</span>
             <strong id="session-expiry-countdown" class="session-expiry-countdown">5:00</strong>
         </div>
         <div class="session-expiry-actions">
-            <button type="button" class="btn btn-sm session-expiry-extend" onclick="sessionExtend()">{{ t('session.expiry.extend') }}</button>
-            <button type="button" class="session-expiry-dismiss" onclick="sessionDismiss()" aria-label="{{ t('session.expiry.dismiss') }}">&#10005;</button>
+            <button type="button" class="btn btn-sm session-expiry-extend" data-action="session-extend">{{ t('session.expiry.extend') }}</button>
+            <button type="button" class="session-expiry-dismiss" data-action="session-dismiss" aria-label="{{ t('session.expiry.dismiss') }}">&#10005;</button>
         </div>
     </div>
     {% endif %}
@@ -142,12 +147,12 @@
             {{ brand.name }} &middot; {{ t('footer.tagline') }} &middot;
             <a href="https://github.com/openwhistle/OpenWhistle" rel="noopener">{{ t('footer.open_source') }}</a>
             &middot; <a href="https://www.gesetze-im-internet.de/hinschg/" rel="noopener">HinSchG</a>
-            &middot; <a href="/admin" style="opacity:0.4;" title="{{ t('footer.admin_title') }}">{{ t('footer.admin') }}</a>
+            &middot; <a href="/admin" class="u-dim" title="{{ t('footer.admin_title') }}">{{ t('footer.admin') }}</a>
         </p>
     </footer>
 
-    <script src="/static/js/site.js"></script>
-    <script>
+    <script src="/static/js/site.js" nonce="{{ request.state.csp_nonce }}"></script>
+    <script nonce="{{ request.state.csp_nonce }}">
     (function() {
         function pad(n) { return n < 10 ? '0' + n : '' + n; }
         function tzLabel(d) {
@@ -170,7 +175,7 @@
         });
     })();
     </script>
-    <script>
+    <script nonce="{{ request.state.csp_nonce }}">
     // Language picker dropdown
     (function() {
         var btn = document.getElementById('lang-picker-btn');

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -2,12 +2,33 @@
 
 {% block title %}Error {{ status_code }} | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.err-container { text-align:center;padding:3rem 1rem; }
+.err-back-btn { margin-top:1rem; }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="container-sm" style="text-align:center;padding:3rem 1rem;">
+<div class="container-sm err-container">
     <div class="page-header">
         <div class="page-eyebrow">Error {{ status_code }}</div>
         <h1>{{ detail }}</h1>
     </div>
-    <a href="javascript:history.back()" class="btn btn-secondary" style="margin-top:1rem;">Go Back</a>
+    <a href="#" id="err-back-link" class="btn btn-secondary err-back-btn">Go Back</a>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ request.state.csp_nonce }}">
+document.addEventListener('DOMContentLoaded', () => {
+    const link = document.getElementById('err-back-link');
+    if (link) {
+        link.addEventListener('click', (e) => {
+            e.preventDefault();
+            history.back();
+        });
+    }
+});
+</script>
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,5 +1,21 @@
 {% extends "base.html" %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+    .lg-page-center { min-height: calc(100vh - 56px - 56px); display: flex; align-items: center; justify-content: center; padding: 2rem 1rem; }
+    .lg-card-width { width: 100%; max-width: 400px; }
+    .lg-header { margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both; }
+    .lg-h1 { font-size: clamp(1.5rem, 4vw, 2.25rem); }
+    .lg-subtitle { font-size: 0.88rem; margin-top: 0.5rem; }
+    .lg-panel-anim { animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards; }
+    .lg-btn-mt { margin-top: 0.5rem; }
+    .lg-oidc-wrap { margin-top: 1.5rem; text-align: center; }
+    .lg-or-label { font-size: 0.78rem; color: var(--muted); margin-bottom: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; }
+    .lg-ldap-wrap { margin-top: 0.75rem; text-align: center; }
+    .lg-ldap-badge { display: inline-block; font-size: 0.72rem; color: var(--muted); background: var(--surface-2,var(--surface-card)); border: 1px solid var(--hairline); border-radius: 4px; padding: 0.2rem 0.6rem; }
+</style>
+{% endblock %}
+
 {% block title %}{{ t('login.title') }} | OpenWhistle{% endblock %}
 
 {% block nav_links %}
@@ -8,13 +24,13 @@
 {% endblock %}
 
 {% block content %}
-<div style="min-height: calc(100vh - 56px - 56px); display: flex; align-items: center; justify-content: center; padding: 2rem 1rem;">
-    <div style="width: 100%; max-width: 400px;">
+<div class="lg-page-center">
+    <div class="lg-card-width">
 
-        <div style="margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both;">
+        <div class="lg-header">
             <div class="page-eyebrow">{{ t('login.eyebrow') }}</div>
-            <h1 style="font-size: clamp(1.5rem, 4vw, 2.25rem);">{{ t('login.title') }}</h1>
-            <p style="font-size: 0.88rem; margin-top: 0.5rem;">{{ t('login.subtitle') }}</p>
+            <h1 class="lg-h1">{{ t('login.title') }}</h1>
+            <p class="lg-subtitle">{{ t('login.subtitle') }}</p>
         </div>
 
         {% if is_demo %}
@@ -26,13 +42,13 @@
             <div class="demo-credentials-grid">
                 <div class="demo-cred-item">
                     <span class="demo-cred-label">Username</span>
-                    <button type="button" class="demo-cred-value" onclick="document.getElementById('username').value='demo';document.getElementById('password').value='demo';" title="Click to fill">
+                    <button type="button" id="demo-fill-btn-user" class="demo-cred-value" title="Click to fill">
                         demo
                     </button>
                 </div>
                 <div class="demo-cred-item">
                     <span class="demo-cred-label">Password</span>
-                    <button type="button" class="demo-cred-value" onclick="document.getElementById('username').value='demo';document.getElementById('password').value='demo';" title="Click to fill">
+                    <button type="button" id="demo-fill-btn-pass" class="demo-cred-value" title="Click to fill">
                         demo
                     </button>
                 </div>
@@ -41,7 +57,7 @@
                     <code class="demo-cred-code">0 0 0 0 0 0</code>
                 </div>
             </div>
-            <button type="button" class="demo-fill-btn" onclick="document.getElementById('username').value='demo';document.getElementById('password').value='demo';this.textContent='✓ Filled';">
+            <button type="button" id="demo-fill-btn-all" class="demo-fill-btn">
                 Fill credentials
             </button>
         </div>
@@ -51,7 +67,7 @@
         <div class="alert alert-error" role="alert">{{ error }}</div>
         {% endif %}
 
-        <div class="panel" style="animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards;">
+        <div class="panel lg-panel-anim">
             <div class="panel-header">{{ t('login.panel.header') }}</div>
 
             <form method="post" action="/admin/login" novalidate>
@@ -80,22 +96,22 @@
                         required>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block" style="margin-top: 0.5rem;">
+                <button type="submit" class="btn btn-primary btn-block lg-btn-mt">
                     {{ t('login.submit') }}
                 </button>
             </form>
 
             {% if oidc_enabled %}
-            <div style="margin-top:1.5rem;text-align:center;">
-                <div style="font-size:0.78rem;color:var(--muted);margin-bottom:0.75rem;text-transform:uppercase;letter-spacing:0.08em;">{{ t('login.or') }}</div>
+            <div class="lg-oidc-wrap">
+                <div class="lg-or-label">{{ t('login.or') }}</div>
                 <a href="/admin/oidc/authorize" class="btn btn-secondary btn-block">
                     {{ t('login.sso') }}
                 </a>
             </div>
             {% endif %}
             {% if ldap_enabled %}
-            <div style="margin-top:0.75rem;text-align:center;">
-                <span style="display:inline-block;font-size:0.72rem;color:var(--muted);background:var(--surface-2,var(--surface-card));border:1px solid var(--hairline);border-radius:4px;padding:0.2rem 0.6rem;">
+            <div class="lg-ldap-wrap">
+                <span class="lg-ldap-badge">
                     {{ t('login.ldap_active') }}
                 </span>
             </div>
@@ -104,4 +120,28 @@
 
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ request.state.csp_nonce }}">
+(function() {
+    function fillDemoCredentials() {
+        var u = document.getElementById('username');
+        var p = document.getElementById('password');
+        if (u) u.value = 'demo';
+        if (p) p.value = 'demo';
+    }
+    var userBtn = document.getElementById('demo-fill-btn-user');
+    var passBtn = document.getElementById('demo-fill-btn-pass');
+    var allBtn = document.getElementById('demo-fill-btn-all');
+    if (userBtn) userBtn.addEventListener('click', fillDemoCredentials);
+    if (passBtn) passBtn.addEventListener('click', fillDemoCredentials);
+    if (allBtn) {
+        allBtn.addEventListener('click', function() {
+            fillDemoCredentials();
+            this.textContent = '✓ Filled';
+        });
+    }
+})();
+</script>
 {% endblock %}

--- a/app/templates/login_mfa.html
+++ b/app/templates/login_mfa.html
@@ -1,15 +1,29 @@
 {% extends "base.html" %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+    .mfa-page-center { min-height: calc(100vh - 56px - 56px); display: flex; align-items: center; justify-content: center; padding: 2rem 1rem; }
+    .mfa-card-width { width: 100%; max-width: 400px; }
+    .mfa-header { margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both; }
+    .mfa-h1 { font-size: clamp(1.5rem, 4vw, 2.25rem); }
+    .mfa-subtitle { font-size: 0.88rem; margin-top: 0.5rem; }
+    .mfa-panel-anim { animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards; }
+    .mfa-code-input { font-size: 1.75rem; letter-spacing: 0.4em; text-align: center; padding-bottom: 0.75rem; }
+    .mfa-btn-mt { margin-top: 0.5rem; }
+    .mfa-back-wrap { margin-top: 1.25rem; text-align: center; }
+</style>
+{% endblock %}
+
 {% block title %}{{ t('mfa.title') }} | OpenWhistle{% endblock %}
 
 {% block content %}
-<div style="min-height: calc(100vh - 56px - 56px); display: flex; align-items: center; justify-content: center; padding: 2rem 1rem;">
-    <div style="width: 100%; max-width: 400px;">
+<div class="mfa-page-center">
+    <div class="mfa-card-width">
 
-        <div style="margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both;">
+        <div class="mfa-header">
             <div class="page-eyebrow">{{ t('mfa.eyebrow') }}</div>
-            <h1 style="font-size: clamp(1.5rem, 4vw, 2.25rem);">{{ t('mfa.title') }}</h1>
-            <p style="font-size: 0.88rem; margin-top: 0.5rem;">{{ t('mfa.subtitle') }}</p>
+            <h1 class="mfa-h1">{{ t('mfa.title') }}</h1>
+            <p class="mfa-subtitle">{{ t('mfa.subtitle') }}</p>
         </div>
 
         {% if error %}
@@ -23,7 +37,7 @@
         </div>
         {% endif %}
 
-        <div class="panel" style="animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards;">
+        <div class="panel mfa-panel-anim">
             <div class="panel-header">{{ t('mfa.panel.header') }}</div>
 
             <form method="post" action="/admin/login/mfa" novalidate>
@@ -34,7 +48,7 @@
                     <label class="form-label" for="totp_code">{{ t('mfa.code.label') }}</label>
                     <input
                         type="text"
-                        class="form-control mono"
+                        class="form-control mono mfa-code-input"
                         id="totp_code"
                         name="totp_code"
                         inputmode="numeric"
@@ -43,17 +57,16 @@
                         autocomplete="one-time-code"
                         placeholder="0 0 0 0 0 0"
                         required
-                        autofocus
-                        style="font-size:1.75rem;letter-spacing:0.4em;text-align:center;padding-bottom:0.75rem;">
+                        autofocus>
                     <div class="form-hint">{{ t('mfa.code.hint') }}</div>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block" style="margin-top: 0.5rem;">
+                <button type="submit" class="btn btn-primary btn-block mfa-btn-mt">
                     {{ t('mfa.submit') }}
                 </button>
             </form>
 
-            <div style="margin-top:1.25rem;text-align:center;">
+            <div class="mfa-back-wrap">
                 <a href="/admin/login" class="btn btn-secondary btn-sm">{{ t('mfa.back') }}</a>
             </div>
         </div>

--- a/app/templates/login_mfa_setup.html
+++ b/app/templates/login_mfa_setup.html
@@ -2,47 +2,70 @@
 
 {% block title %}{{ t('mfa.setup.title') }} — OpenWhistle{% endblock %}
 
-{% block content %}
-<div style="min-height: calc(100vh - 56px - 56px); display: flex; align-items: center; justify-content: center; padding: 2rem 1rem;">
-    <div style="width: 100%; max-width: 480px;">
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+    .mfas-center-page { min-height: calc(100vh - 56px - 56px); display: flex; align-items: center; justify-content: center; padding: 2rem 1rem; }
+    .mfas-card { width: 100%; max-width: 480px; }
+    .mfas-header { margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both; }
+    .mfas-title { font-size: clamp(1.5rem, 4vw, 2.25rem); }
+    .mfas-subtitle { font-size: 0.88rem; margin-top: 0.5rem; }
+    .mfas-panel-1 { animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards; }
+    .mfas-panel-2 { animation: fadeSlideIn 0.5s 0.18s ease both; opacity: 0; animation-fill-mode: forwards; margin-top: 1.25rem; }
+    .mfas-step-body { font-size: 0.88rem; margin-bottom: 1rem; }
+    .mfas-qr-wrap { text-align: center; margin: 1.5rem 0; }
+    .mfas-qr-img { border: 4px solid var(--border); border-radius: 8px; image-rendering: pixelated; }
+    .mfas-details { margin-bottom: 1.5rem; }
+    .mfas-summary { font-size: 0.82rem; cursor: pointer; color: var(--text-muted); }
+    .mfas-manual-box { margin-top: 0.75rem; background: var(--bg-secondary); border-radius: 6px; padding: 0.75rem 1rem; }
+    .mfas-manual-label { font-size: 0.78rem; color: var(--text-muted); margin-bottom: 0.4rem; }
+    .mfas-manual-code { font-size: 0.9rem; letter-spacing: 0.1em; word-break: break-all; }
+    .mfas-code-input { font-size: 1.75rem; letter-spacing: 0.4em; text-align: center; padding-bottom: 0.75rem; }
+    .mfas-submit { margin-top: 0.5rem; }
+    .mfas-back-wrap { margin-top: 1.25rem; text-align: center; }
+</style>
+{% endblock %}
 
-        <div style="margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both;">
+{% block content %}
+<div class="mfas-center-page">
+    <div class="mfas-card">
+
+        <div class="mfas-header">
             <div class="page-eyebrow">{{ t('mfa.setup.eyebrow') }}</div>
-            <h1 style="font-size: clamp(1.5rem, 4vw, 2.25rem);">{{ t('mfa.setup.title') }}</h1>
-            <p style="font-size: 0.88rem; margin-top: 0.5rem;">{{ t('mfa.setup.subtitle') }}</p>
+            <h1 class="mfas-title">{{ t('mfa.setup.title') }}</h1>
+            <p class="mfas-subtitle">{{ t('mfa.setup.subtitle') }}</p>
         </div>
 
         {% if error %}
         <div class="alert alert-error" role="alert">{{ error }}</div>
         {% endif %}
 
-        <div class="panel" style="animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards;">
+        <div class="panel mfas-panel-1">
             <div class="panel-header">{{ t('mfa.setup.step1.header') }}</div>
-            <p style="font-size: 0.88rem; margin-bottom: 1rem;">{{ t('mfa.setup.step1.body') }}</p>
+            <p class="mfas-step-body">{{ t('mfa.setup.step1.body') }}</p>
 
-            <div style="text-align: center; margin: 1.5rem 0;">
+            <div class="mfas-qr-wrap">
                 <img
                     src="data:image/png;base64,{{ qr_b64 }}"
                     alt="{{ t('mfa.setup.qr.alt') }}"
                     width="200"
                     height="200"
-                    style="border: 4px solid var(--border); border-radius: 8px; image-rendering: pixelated;">
+                    class="mfas-qr-img">
             </div>
 
-            <details style="margin-bottom: 1.5rem;">
-                <summary style="font-size: 0.82rem; cursor: pointer; color: var(--text-muted);">
+            <details class="mfas-details">
+                <summary class="mfas-summary">
                     {{ t('mfa.setup.manual.summary') }}
                 </summary>
-                <div style="margin-top: 0.75rem; background: var(--bg-secondary); border-radius: 6px; padding: 0.75rem 1rem;">
-                    <p style="font-size: 0.78rem; color: var(--text-muted); margin-bottom: 0.4rem;">{{ t('mfa.setup.manual.label') }}</p>
-                    <code style="font-size: 0.9rem; letter-spacing: 0.1em; word-break: break-all;">{{ totp_secret }}</code>
+                <div class="mfas-manual-box">
+                    <p class="mfas-manual-label">{{ t('mfa.setup.manual.label') }}</p>
+                    <code class="mfas-manual-code">{{ totp_secret }}</code>
                 </div>
             </details>
         </div>
 
-        <div class="panel" style="animation: fadeSlideIn 0.5s 0.18s ease both; opacity: 0; animation-fill-mode: forwards; margin-top: 1.25rem;">
+        <div class="panel mfas-panel-2">
             <div class="panel-header">{{ t('mfa.setup.step2.header') }}</div>
-            <p style="font-size: 0.88rem; margin-bottom: 1rem;">{{ t('mfa.setup.step2.body') }}</p>
+            <p class="mfas-step-body">{{ t('mfa.setup.step2.body') }}</p>
 
             <form method="post" action="/admin/mfa/setup" novalidate>
                 <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
@@ -52,7 +75,7 @@
                     <label class="form-label" for="totp_code">{{ t('mfa.setup.code.label') }}</label>
                     <input
                         type="text"
-                        class="form-control mono"
+                        class="form-control mono mfas-code-input"
                         id="totp_code"
                         name="totp_code"
                         inputmode="numeric"
@@ -61,17 +84,16 @@
                         autocomplete="one-time-code"
                         placeholder="0 0 0 0 0 0"
                         required
-                        autofocus
-                        style="font-size:1.75rem;letter-spacing:0.4em;text-align:center;padding-bottom:0.75rem;">
+                        autofocus>
                     <div class="form-hint">{{ t('mfa.setup.code.hint') }}</div>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block" style="margin-top: 0.5rem;">
+                <button type="submit" class="btn btn-primary btn-block mfas-submit">
                     {{ t('mfa.setup.submit') }}
                 </button>
             </form>
 
-            <div style="margin-top:1.25rem;text-align:center;">
+            <div class="mfas-back-wrap">
                 <a href="/admin/login" class="btn btn-secondary btn-sm">{{ t('mfa.back') }}</a>
             </div>
         </div>

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -1,5 +1,31 @@
 {% extends "base.html" %}
 
+{% block styles %}<style nonce="{{ request.state.csp_nonce }}">
+.st-demo-credentials-margin { margin-bottom: 1.5rem; }
+.st-lockout-countdown { margin-top: 0.6rem; font-size: 0.85rem; opacity: 0.85; }
+.st-pin-wrapper { position: relative; }
+.st-pin-input { padding-right: 5rem; }
+.st-pin-toggle { position: absolute; right: 0.75rem; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--muted); font-size: 0.72rem; font-family: var(--font-body); font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; cursor: pointer; padding: 0.2rem 0.3rem; }
+.st-meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; font-size: 0.85rem; color: var(--muted); }
+.st-mono-primary { color: var(--text-primary); }
+.st-deadlines-section { margin-top: 1.25rem; padding-top: 1rem; border-top: 1px solid var(--hairline); }
+.st-deadlines-title { margin-bottom: 0.6rem; font-size: 0.78rem; letter-spacing: 0.08em; text-transform: uppercase; }
+.st-deadlines-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; font-size: 0.83rem; }
+.st-deadline-label { color: var(--muted); margin-bottom: 0.2rem; }
+.st-success-text { color: var(--success, #2a7a2a); font-weight: 600; }
+.st-accent-text { color: var(--accent); font-weight: 600; }
+.st-danger-text { color: var(--danger); font-weight: 600; }
+.st-fw600 { font-weight: 600; }
+.st-muted-italic { color: var(--muted); font-style: italic; }
+.st-muted-text { color: var(--muted); }
+.st-delay-03 { animation-delay: 0.03s; }
+.st-delay-04 { animation-delay: 0.04s; }
+.st-delay-05 { animation-delay: 0.05s; }
+.st-delay-10 { animation-delay: 0.1s; }
+.st-footer-section { margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--hairline); text-align: center; }
+.st-footer-text { font-size: 0.82rem; color: var(--muted); margin-bottom: 0.75rem; }
+</style>{% endblock %}
+
 {% block title %}{{ t('status.form.title') }} | OpenWhistle{% endblock %}
 
 {% block content %}
@@ -12,29 +38,29 @@
     </div>
 
     {% if is_demo %}
-    <div class="demo-credentials" role="note" style="margin-bottom:1.5rem;">
+    <div class="demo-credentials st-demo-credentials-margin" role="note">
         <div class="demo-credentials-header">
             <span class="demo-badge">DEMO</span>
             <span>Try these example reports. Click any row to pre-fill.</span>
         </div>
         <div class="demo-reports-list">
             <button type="button" class="demo-report-row"
-                onclick="document.getElementById('case_number').value='OW-DEMO-00001';document.getElementById('pin').value='demo-pin-received-00001';">
+                data-case="OW-DEMO-00001" data-pin="demo-pin-received-00001">
                 <code class="demo-cred-code">OW-DEMO-00001</code>
                 <span class="demo-report-status status-badge status-received">Received</span>
             </button>
             <button type="button" class="demo-report-row"
-                onclick="document.getElementById('case_number').value='OW-DEMO-00002';document.getElementById('pin').value='demo-pin-inreview-00002';">
+                data-case="OW-DEMO-00002" data-pin="demo-pin-inreview-00002">
                 <code class="demo-cred-code">OW-DEMO-00002</code>
                 <span class="demo-report-status status-badge status-in_review">In Review</span>
             </button>
             <button type="button" class="demo-report-row"
-                onclick="document.getElementById('case_number').value='OW-DEMO-00003';document.getElementById('pin').value='demo-pin-pending-00003';">
+                data-case="OW-DEMO-00003" data-pin="demo-pin-pending-00003">
                 <code class="demo-cred-code">OW-DEMO-00003</code>
                 <span class="demo-report-status status-badge status-pending_feedback">Pending Feedback</span>
             </button>
             <button type="button" class="demo-report-row"
-                onclick="document.getElementById('case_number').value='OW-DEMO-00004';document.getElementById('pin').value='demo-pin-closed-00004';">
+                data-case="OW-DEMO-00004" data-pin="demo-pin-closed-00004">
                 <code class="demo-cred-code">OW-DEMO-00004</code>
                 <span class="demo-report-status status-badge status-closed">Closed</span>
             </button>
@@ -51,10 +77,10 @@
         <div class="alert-title">{{ t('status.locked.title') }}</div>
         {{ t('status.locked.body') }}
         {% if lockout_ttl and lockout_ttl > 0 %}
-        <div style="margin-top:0.6rem;font-size:0.85rem;opacity:0.85;">
+        <div class="st-lockout-countdown">
             <span id="lockout-countdown">{{ lockout_ttl }}</span> {{ t('status.locked.countdown') }}
         </div>
-        <script>
+        <script nonce="{{ request.state.csp_nonce }}">
         (function() {
             var el = document.getElementById('lockout-countdown');
             var t = {{ lockout_ttl }};
@@ -91,21 +117,21 @@
 
             <div class="form-group">
                 <label class="form-label" for="pin">{{ t('status.pin.label') }}</label>
-                <div style="position:relative;">
+                <div class="st-pin-wrapper">
                     <input
                         type="password"
-                        class="form-control mono"
+                        class="form-control mono st-pin-input"
                         id="pin"
                         name="pin"
                         placeholder="{{ t('status.pin.placeholder') }}"
                         required
                         autocomplete="off"
-                        spellcheck="false"
-                        style="padding-right:5rem;">
+                        spellcheck="false">
                     <button type="button"
                         id="pin-toggle"
-                        onclick="var i=document.getElementById('pin');var show=i.type==='password';i.type=show?'text':'password';this.textContent=show?'{{ t('status.pin.hide') }}':'{{ t('status.pin.show') }}';"
-                        style="position:absolute;right:0.75rem;top:50%;transform:translateY(-50%);background:none;border:none;color:var(--muted);font-size:0.72rem;font-family:var(--font-body);font-weight:700;letter-spacing:0.06em;text-transform:uppercase;cursor:pointer;padding:0.2rem 0.3rem;">{{ t('status.pin.show') }}</button>
+                        class="st-pin-toggle"
+                        data-label-show="{{ t('status.pin.show') }}"
+                        data-label-hide="{{ t('status.pin.hide') }}">{{ t('status.pin.show') }}</button>
                 </div>
                 <div class="form-hint">{{ t('status.pin.hint') }}</div>
             </div>
@@ -137,54 +163,54 @@
             <span class="badge badge-{{ report.status.value }}">{{ t('status.label.' + report.status.value) }}</span>
         </div>
 
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;font-size:0.85rem;color:var(--muted);">
+        <div class="st-meta-grid">
             <div>
                 <div class="detail-label">{{ t('status.meta.submitted') }}</div>
-                <span class="mono" style="color:var(--text-primary);"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
+                <span class="mono st-mono-primary"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
             </div>
             {% if report.acknowledged_at %}
             <div>
                 <div class="detail-label">{{ t('status.meta.acknowledged') }}</div>
-                <span class="mono" style="color:var(--text-primary);"><time data-utc="{{ report.acknowledged_at.isoformat() }}">{{ report.acknowledged_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
+                <span class="mono st-mono-primary"><time data-utc="{{ report.acknowledged_at.isoformat() }}">{{ report.acknowledged_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
             </div>
             {% endif %}
             {% if report.feedback_due_at %}
             <div>
                 <div class="detail-label">{{ t('status.meta.feedback_due') }}</div>
-                <span class="mono" style="color:var(--text-primary);">{{ report.feedback_due_at.strftime('%Y-%m-%d') }}</span>
+                <span class="mono st-mono-primary">{{ report.feedback_due_at.strftime('%Y-%m-%d') }}</span>
             </div>
             {% endif %}
         </div>
 
         {# HinSchG deadline display #}
-        <div style="margin-top:1.25rem;padding-top:1rem;border-top:1px solid var(--hairline);">
-            <div class="detail-label" style="margin-bottom:0.6rem;font-size:0.78rem;letter-spacing:0.08em;text-transform:uppercase;">{{ t('status.deadlines.title') }}</div>
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;font-size:0.83rem;">
+        <div class="st-deadlines-section">
+            <div class="detail-label st-deadlines-title">{{ t('status.deadlines.title') }}</div>
+            <div class="st-deadlines-grid">
                 <div>
-                    <div style="color:var(--muted);margin-bottom:0.2rem;">{{ t('status.deadlines.ack') }}</div>
+                    <div class="st-deadline-label">{{ t('status.deadlines.ack') }}</div>
                     {% if report.acknowledged_at %}
-                    <span style="color:var(--success, #2a7a2a);font-weight:600;">✓ {{ t('status.deadlines.ack_done', date=report.acknowledged_at.strftime('%Y-%m-%d')) }}</span>
+                    <span class="st-success-text">✓ {{ t('status.deadlines.ack_done', date=report.acknowledged_at.strftime('%Y-%m-%d')) }}</span>
                     {% elif ack_days_remaining is defined and ack_days_remaining >= 0 %}
-                    <span style="color:var(--accent);font-weight:600;">{{ t('status.deadlines.ack_remaining', days=ack_days_remaining) }}</span>
+                    <span class="st-accent-text">{{ t('status.deadlines.ack_remaining', days=ack_days_remaining) }}</span>
                     {% else %}
-                    <span style="color:var(--danger);font-weight:600;">{{ t('status.deadlines.ack_overdue') }}</span>
+                    <span class="st-danger-text">{{ t('status.deadlines.ack_overdue') }}</span>
                     {% endif %}
                 </div>
                 <div>
-                    <div style="color:var(--muted);margin-bottom:0.2rem;">{{ t('status.deadlines.feedback') }}</div>
+                    <div class="st-deadline-label">{{ t('status.deadlines.feedback') }}</div>
                     {% if report.acknowledged_at and report.feedback_due_at %}
                         {% if now is defined %}
                             {% set days_left = ((report.feedback_due_at - now).days) %}
                             {% if report.status.value == 'closed' %}
-                            <span style="color:var(--success, #2a7a2a);font-weight:600;">✓ {{ t('status.deadlines.feedback_done') }}</span>
+                            <span class="st-success-text">✓ {{ t('status.deadlines.feedback_done') }}</span>
                             {% elif days_left >= 0 %}
-                            <span style="font-weight:600;">{{ t('status.deadlines.feedback_remaining', days=days_left, date=report.feedback_due_at.strftime('%Y-%m-%d')) }}</span>
+                            <span class="st-fw600">{{ t('status.deadlines.feedback_remaining', days=days_left, date=report.feedback_due_at.strftime('%Y-%m-%d')) }}</span>
                             {% else %}
-                            <span style="color:var(--danger);font-weight:600;">{{ t('status.deadlines.feedback_overdue') }}</span>
+                            <span class="st-danger-text">{{ t('status.deadlines.feedback_overdue') }}</span>
                             {% endif %}
                         {% endif %}
                     {% else %}
-                    <span style="color:var(--muted);font-style:italic;">{{ t('status.deadlines.feedback_pending') }}</span>
+                    <span class="st-muted-italic">{{ t('status.deadlines.feedback_pending') }}</span>
                     {% endif %}
                 </div>
             </div>
@@ -192,7 +218,7 @@
     </div>
 
     {# Progress indicator #}
-    <div class="panel status-progress-panel" style="animation-delay:0.03s;">
+    <div class="panel status-progress-panel st-delay-03">
         <div class="panel-header">{{ t('status.progress.title') }}</div>
         <div class="progress-steps">
             {% set steps = ['received', 'in_review', 'pending_feedback', 'closed'] %}
@@ -216,7 +242,7 @@
 
     {# Attachments #}
     {% if report.attachments %}
-    <div class="panel" style="animation-delay:0.04s;">
+    <div class="panel st-delay-04">
         <div class="panel-header">{{ t('status.attachments.title') }}</div>
         <ul class="attachment-items">
             {% for att in report.attachments %}
@@ -233,14 +259,14 @@
 
     {# Case closed notice #}
     {% if report.status.value == 'closed' %}
-    <div class="alert alert-info" role="alert" style="animation-delay:0.04s;">
+    <div class="alert alert-info st-delay-04" role="alert">
         <div class="alert-title">{{ t('status.closed.title') }}</div>
         {{ t('status.closed.body') }}
     </div>
     {% endif %}
 
     {# Communication thread #}
-    <div class="panel" style="animation-delay:0.05s;">
+    <div class="panel st-delay-05">
         <div class="panel-header">{{ t('status.thread.title') }}</div>
 
         {% if report.messages %}
@@ -257,12 +283,12 @@
             {% endfor %}
         </div>
         {% else %}
-        <p style="color:var(--muted);">{{ t('status.no_messages') }}</p>
+        <p class="st-muted-text">{{ t('status.no_messages') }}</p>
         {% endif %}
     </div>
 
     {% if report.status.value != 'closed' %}
-    <div class="panel" style="animation-delay:0.1s;">
+    <div class="panel st-delay-10">
         <div class="panel-header">{{ t('status.reply.title') }}</div>
         <form method="post" action="/reply">
             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
@@ -287,11 +313,36 @@
     </div>
     {% endif %}
 
-    <div style="margin-top:1.5rem;padding-top:1.5rem;border-top:1px solid var(--hairline);text-align:center;">
-        <p style="font-size:0.82rem;color:var(--muted);margin-bottom:0.75rem;">{{ t('status.other.title') }}</p>
+    <div class="st-footer-section">
+        <p class="st-footer-text">{{ t('status.other.title') }}</p>
         <a href="/status/logout" class="btn btn-secondary">{{ t('status.other.button') }}</a>
     </div>
 
     {% endif %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ request.state.csp_nonce }}">
+(function() {
+    document.querySelectorAll('.demo-report-row').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            var caseInput = document.getElementById('case_number');
+            var pinInput = document.getElementById('pin');
+            if (caseInput) caseInput.value = btn.dataset.case;
+            if (pinInput) pinInput.value = btn.dataset.pin;
+        });
+    });
+
+    var toggle = document.getElementById('pin-toggle');
+    if (toggle) {
+        toggle.addEventListener('click', function() {
+            var i = document.getElementById('pin');
+            var show = i.type === 'password';
+            i.type = show ? 'text' : 'password';
+            toggle.textContent = show ? toggle.dataset.labelHide : toggle.dataset.labelShow;
+        });
+    }
+})();
+</script>
 {% endblock %}

--- a/app/templates/submit.html
+++ b/app/templates/submit.html
@@ -1,5 +1,21 @@
 {% extends "base.html" %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+    .sub-alert-spaced { margin: 1rem 0; }
+    .sub-fieldset-reset { border: none; padding: 0; margin: 0; }
+    .sub-mb1 { margin-bottom: 1rem; }
+    .sub-confidential-fields { display: none; margin-top: 1.5rem; }
+    .sub-label-flex { display: flex; justify-content: space-between; align-items: baseline; }
+    .sub-char-counter { font-size: 0.72rem; font-weight: 400; color: var(--muted); font-family: var(--font-mono); }
+    .sub-row-top { align-items: flex-start; }
+    .sub-review-desc { white-space: pre-wrap; font-size: 0.88rem; max-height: 200px; overflow-y: auto; }
+    .sub-file-list { list-style: none; padding: 0; margin: 0; }
+    .sub-muted { color: var(--muted); }
+    .sub-restart-p { text-align: center; margin-top: 1rem; font-size: 0.8rem; color: var(--muted); }
+</style>
+{% endblock %}
+
 {% block title %}{{ t('submit.title') }} | OpenWhistle{% endblock %}
 
 {% block content %}
@@ -79,7 +95,7 @@
 
         {# ── Step 1: Mode selection ── #}
         {% if step == 1 %}
-        <div class="alert alert-info" style="margin: 1rem 0;">
+        <div class="alert alert-info sub-alert-spaced">
             <div class="alert-title">{{ t('submit.alert.title') }}</div>
             {{ t('submit.alert.body') }}
         </div>
@@ -88,8 +104,8 @@
             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
             <input type="hidden" name="step" value="1">
 
-            <fieldset style="border:none;padding:0;margin:0;">
-                <legend class="form-label" style="margin-bottom:1rem;">{{ t('submit.step.mode.title') }}</legend>
+            <fieldset class="sub-fieldset-reset">
+                <legend class="form-label sub-mb1">{{ t('submit.step.mode.title') }}</legend>
 
                 <div class="mode-cards">
                     <label class="mode-card" for="mode-anonymous">
@@ -116,8 +132,8 @@
                 </div>
             </fieldset>
 
-            <div id="confidential-fields" style="display:none;margin-top:1.5rem;">
-                <div class="alert alert-info" style="margin-bottom:1rem;">
+            <div id="confidential-fields" class="sub-confidential-fields">
+                <div class="alert alert-info sub-mb1">
                     <div class="alert-title">{{ t('submit.step.mode.confidential.info.title') }}</div>
                     {{ t('submit.step.mode.confidential.info.body') }}
                 </div>
@@ -160,19 +176,6 @@
                 </button>
             </div>
         </form>
-
-        <script>
-        (function() {
-            var radios = document.querySelectorAll('input[name="submission_mode"]');
-            var fields = document.getElementById('confidential-fields');
-            function toggle() {
-                var checked = document.querySelector('input[name="submission_mode"]:checked');
-                fields.style.display = checked && checked.value === 'confidential' ? 'block' : 'none';
-            }
-            radios.forEach(function(r) { r.addEventListener('change', toggle); });
-            toggle();
-        })();
-        </script>
 
         {# ── Step 2: Location (conditional) ── #}
         {% elif step == 2 and has_locations %}
@@ -240,9 +243,9 @@
             <input type="hidden" name="step" value="{{ step }}">
 
             <div class="form-group">
-                <label class="form-label" for="description" style="display:flex;justify-content:space-between;align-items:baseline;">
+                <label class="form-label sub-label-flex" for="description">
                     <span>{{ t('submit.form.description') }}</span>
-                    <span id="char-counter" style="font-size:0.72rem;font-weight:400;color:var(--muted);font-family:var(--font-mono);">{{ state.get('description', '') | length | string }} / 10,000</span>
+                    <span id="char-counter" class="sub-char-counter">{{ state.get('description', '') | length | string }} / 10,000</span>
                 </label>
                 <textarea
                     class="form-control"
@@ -255,7 +258,6 @@
                     aria-required="true"
                     aria-describedby="description-hint char-counter"
                     placeholder="{{ t('submit.form.description.placeholder') }}"
-                    oninput="var c=this.value.length;var el=document.getElementById('char-counter');el.textContent=c.toLocaleString()+' / 10,000';el.style.color=c<10?'var(--danger)':c>9500?'var(--warning, #c17b2a)':'var(--muted)';"
                 >{{ state.get('description', '') }}</textarea>
                 <div class="form-hint" id="description-hint">{{ t('submit.form.description.hint') }}</div>
             </div>
@@ -276,7 +278,7 @@
             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
             <input type="hidden" name="step" value="{{ step }}">
 
-            <div class="alert alert-info" style="margin-bottom:1rem;">
+            <div class="alert alert-info sub-mb1">
                 {{ t('submit.step.attachments.info') }}
             </div>
 
@@ -305,12 +307,12 @@
 
         {# ── Step 6: Review ── #}
         {% elif step == 6 or (step == 5 and not has_locations) %}
-        <div class="alert alert-warning" role="alert" style="margin-bottom:1rem;">
+        <div class="alert alert-warning sub-mb1" role="alert">
             <div class="alert-title">{{ t('submit.step.review.warning.title') }}</div>
             {{ t('submit.step.review.warning.body') }}
         </div>
 
-        <div class="panel" style="margin-bottom:1rem;">
+        <div class="panel sub-mb1">
             <div class="panel-header">{{ t('submit.step.review.title') }}</div>
 
             <div class="review-row">
@@ -331,7 +333,7 @@
                     {% if state.get('location_id') %}
                         {% for loc in locations %}{% if loc.id|string == state.get('location_id') %}{{ loc.name }}{% endif %}{% endfor %}
                     {% else %}
-                        <em style="color:var(--muted);">{{ t('submit.step.location.none') }}</em>
+                        <em class="sub-muted">{{ t('submit.step.location.none') }}</em>
                     {% endif %}
                 </span>
             </div>
@@ -344,15 +346,15 @@
                 </span>
             </div>
 
-            <div class="review-row" style="align-items:flex-start;">
+            <div class="review-row sub-row-top">
                 <span class="review-label">{{ t('submit.form.description') }}</span>
-                <span class="review-value" style="white-space:pre-wrap;font-size:0.88rem;max-height:200px;overflow-y:auto;">{{ state.get('description', '') }}</span>
+                <span class="review-value sub-review-desc">{{ state.get('description', '') }}</span>
             </div>
 
             {% if state.get('file_meta') %}
-            <div class="review-row" style="align-items:flex-start;">
+            <div class="review-row sub-row-top">
                 <span class="review-label">{{ t('submit.form.files') }}</span>
-                <ul class="review-value" style="list-style:none;padding:0;margin:0;">
+                <ul class="review-value sub-file-list">
                     {% for f in state.get('file_meta', []) %}
                     <li>&#128206; {{ f.filename }} ({{ (f.size // 1024) }}KB)</li>
                     {% endfor %}
@@ -375,10 +377,39 @@
             </div>
         </form>
 
-        <p style="text-align:center;margin-top:1rem;font-size:0.8rem;color:var(--muted);">
-            <a href="/submit/restart" style="color:var(--muted);">{{ t('submit.nav.restart') }}</a>
+        <p class="sub-restart-p">
+            <a href="/submit/restart" class="sub-muted">{{ t('submit.nav.restart') }}</a>
         </p>
         {% endif %}
     </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ request.state.csp_nonce }}">
+(function() {
+    // Step 1: submission mode toggle (show/hide confidential fields)
+    var radios = document.querySelectorAll('input[name="submission_mode"]');
+    var fields = document.getElementById('confidential-fields');
+    if (fields) {
+        var toggle = function() {
+            var checked = document.querySelector('input[name="submission_mode"]:checked');
+            fields.style.display = checked && checked.value === 'confidential' ? 'block' : 'none';
+        };
+        radios.forEach(function(r) { r.addEventListener('change', toggle); });
+        toggle();
+    }
+
+    // Step 4: description character counter
+    var description = document.getElementById('description');
+    var charCounter = document.getElementById('char-counter');
+    if (description && charCounter) {
+        description.addEventListener('input', function() {
+            var c = this.value.length;
+            charCounter.textContent = c.toLocaleString() + ' / 10,000';
+            charCounter.style.color = c < 10 ? 'var(--danger)' : (c > 9500 ? 'var(--warning, #c17b2a)' : 'var(--muted)');
+        });
+    }
+})();
+</script>
 {% endblock %}

--- a/app/templates/submit_success.html
+++ b/app/templates/submit_success.html
@@ -1,29 +1,40 @@
 {% extends "base.html" %}
 
+{% block styles %}<style nonce="{{ request.state.csp_nonce }}">
+.ss-fade-in { animation: fadeSlideIn 0.5s ease both; }
+.ss-fade-in-05 { animation: fadeSlideIn 0.5s 0.05s ease both; opacity: 0; animation-fill-mode: forwards; }
+.ss-fade-in-10 { animation: fadeSlideIn 0.5s 0.1s ease both; opacity: 0; animation-fill-mode: forwards; }
+.ss-mt-lg { margin-top: 1.5rem; }
+.ss-confirm-label { display: flex; align-items: flex-start; gap: 0.75rem; margin-top: 1.5rem; padding: 1rem; background: var(--accent-subtle); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); cursor: pointer; }
+.ss-confirm-checkbox { margin-top: 0.15rem; flex-shrink: 0; accent-color: var(--accent); width: 1rem; height: 1rem; }
+.ss-confirm-text { font-size: 0.88rem; color: var(--body-text); line-height: 1.5; }
+.ss-go-to-status { margin-top: 0.75rem; opacity: 0.4; }
+</style>{% endblock %}
+
 {% block title %}{{ t('success.title') }} | OpenWhistle{% endblock %}
 
 {% block content %}
 <div class="container-sm success-wrapper">
 
-    <div class="success-header" style="animation: fadeSlideIn 0.5s ease both;">
+    <div class="success-header ss-fade-in">
         <span class="success-check">✓</span>
         <h1>{{ t('success.title') }}</h1>
         <p>{{ t('success.subtitle') }}</p>
     </div>
 
-    <div class="alert alert-warning" role="alert" style="animation: fadeSlideIn 0.5s 0.05s ease both; opacity: 0; animation-fill-mode: forwards;">
+    <div class="alert alert-warning ss-fade-in-05" role="alert">
         <div class="alert-title">{{ t('success.warning.title') }}</div>
         {{ t('success.warning.body') }}
     </div>
 
-    <div class="panel" style="animation: fadeSlideIn 0.5s 0.1s ease both; opacity: 0; animation-fill-mode: forwards;">
+    <div class="panel ss-fade-in-10">
         <div class="panel-header">{{ t('success.panel.header') }}</div>
 
         <div class="credential-group">
             <div class="credential-label">{{ t('success.case_number') }}</div>
             <div class="credential-display" id="case-number">
                 <span>{{ case_number }}</span>
-                <button class="copy-btn" onclick="copyToClipboard('{{ case_number }}', this)" title="Copy to clipboard" aria-label="Copy case number">&#10697;</button>
+                <button class="copy-btn" data-action="copy" data-copy="{{ case_number }}" title="Copy to clipboard" aria-label="Copy case number">&#10697;</button>
             </div>
         </div>
 
@@ -31,12 +42,12 @@
             <div class="credential-label">{{ t('success.pin') }}</div>
             <div class="credential-display" id="pin-value">
                 <span>{{ pin }}</span>
-                <button class="copy-btn" onclick="copyToClipboard('{{ pin }}', this)" title="Copy to clipboard" aria-label="Copy secret PIN">&#10697;</button>
+                <button class="copy-btn" data-action="copy" data-copy="{{ pin }}" title="Copy to clipboard" aria-label="Copy secret PIN">&#10697;</button>
             </div>
         </div>
 
         {% if attachments %}
-        <div class="attachment-list" style="margin-top:1.5rem;">
+        <div class="attachment-list ss-mt-lg">
             <div class="credential-label">{{ t('success.attachments.title') }}</div>
             <ul class="attachment-items">
                 {% for att in attachments %}
@@ -50,22 +61,22 @@
         </div>
         {% endif %}
 
-        <div class="alert alert-info" style="margin-top: 1.5rem;">
+        <div class="alert alert-info ss-mt-lg">
             <div class="alert-title">{{ t('success.next.title') }}</div>
             {{ t('success.next.body.html') }}
         </div>
 
-        <label id="confirm-label" class="saved-confirm-label" style="display:flex;align-items:flex-start;gap:0.75rem;margin-top:1.5rem;padding:1rem;background:var(--accent-subtle);border:1px solid var(--border-strong);border-radius:var(--radius-sm);cursor:pointer;">
-            <input type="checkbox" id="confirm-saved" style="margin-top:0.15rem;flex-shrink:0;accent-color:var(--accent);width:1rem;height:1rem;">
-            <span style="font-size:0.88rem;color:var(--body-text);line-height:1.5;">
+        <label id="confirm-label" class="saved-confirm-label ss-confirm-label">
+            <input type="checkbox" id="confirm-saved" class="ss-confirm-checkbox">
+            <span class="ss-confirm-text">
                 {{ t('success.confirm.label.html') }}
             </span>
         </label>
 
-        <a href="/status" id="go-to-status" class="btn btn-primary btn-block" style="margin-top:0.75rem;opacity:0.4;" tabindex="-1" aria-disabled="true">
+        <a href="/status" id="go-to-status" class="btn btn-primary btn-block ss-go-to-status" tabindex="-1" aria-disabled="true">
             {{ t('success.confirm.button') }}
         </a>
-        <script>
+        <script nonce="{{ request.state.csp_nonce }}">
         (function() {
             var cb = document.getElementById('confirm-saved');
             var btn = document.getElementById('go-to-status');

--- a/app/templates/wizard/setup.html
+++ b/app/templates/wizard/setup.html
@@ -2,6 +2,17 @@
 
 {% block title %}{{ t('wizard.title') }} | OpenWhistle{% endblock %}
 
+{% block styles %}
+<style nonce="{{ request.state.csp_nonce }}">
+.setup-error-list { margin:0;padding-left:1.25rem; }
+.setup-manual-text { font-size:0.875rem;text-align:center;color:var(--body-text); }
+.setup-secret-wrap { text-align:center;margin-top:0.5rem; }
+.setup-secret { font-size:0.9rem;user-select:all;word-break:break-all; }
+.setup-panel-delay { animation-delay:0.05s; }
+.setup-totp-input { font-size:1.4rem;letter-spacing:0.3em;text-align:center;padding-bottom:0.6rem; }
+</style>
+{% endblock %}
+
 {% block nav_links %}{% endblock %}
 
 {% block content %}
@@ -19,7 +30,7 @@
 
     {% if errors %}
     <div class="alert alert-error" role="alert">
-        <ul style="margin:0;padding-left:1.25rem;">
+        <ul class="setup-error-list">
             {% for e in errors %}
             <li>{{ e }}</li>
             {% endfor %}
@@ -35,15 +46,15 @@
             <img src="data:image/png;base64,{{ qr_code }}" alt="TOTP QR Code" width="200" height="200">
         </div>
 
-        <p style="font-size:0.875rem;text-align:center;color:var(--body-text);">
+        <p class="setup-manual-text">
             {{ t('wizard.step1.manual') }}
         </p>
-        <div style="text-align:center;margin-top:0.5rem;">
-            <span class="mono" style="font-size:0.9rem;user-select:all;word-break:break-all;">{{ totp_secret }}</span>
+        <div class="setup-secret-wrap">
+            <span class="mono setup-secret">{{ totp_secret }}</span>
         </div>
     </div>
 
-    <div class="panel" style="animation-delay:0.05s;">
+    <div class="panel setup-panel-delay">
         <div class="panel-header">{{ t('wizard.step2.header') }}</div>
 
         <form method="post" action="/setup" novalidate>
@@ -94,7 +105,7 @@
                 <label class="form-label" for="totp_code">{{ t('wizard.totp_code') }}</label>
                 <input
                     type="text"
-                    class="form-control mono"
+                    class="form-control mono setup-totp-input"
                     id="totp_code"
                     name="totp_code"
                     inputmode="numeric"
@@ -102,8 +113,7 @@
                     maxlength="6"
                     placeholder="000000"
                     required
-                    autocomplete="one-time-code"
-                    style="font-size:1.4rem;letter-spacing:0.3em;text-align:center;padding-bottom:0.6rem;">
+                    autocomplete="one-time-code">
                 <div class="form-hint">{{ t('wizard.totp_code.hint') }}</div>
             </div>
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -821,7 +821,7 @@
 
         <h3>Current version</h3>
         <p>
-          <strong>v1.0.0</strong> — Envelope encryption at rest, GDPR data retention, multi-tenancy, superadmin role, telephone channel guide. See the
+          <strong>v1.1.1</strong> — Security release: object-level report authorization (deanonymization / IDOR fix), privilege-escalation guards on role assignment, stored-XSS hardening, and a strict nonce-based Content-Security-Policy with consolidated security headers. See the
           <a href="https://github.com/openwhistle/OpenWhistle/blob/main/CHANGELOG.md" rel="noopener noreferrer" target="_blank">CHANGELOG</a>
           for a full list of changes.
         </p>
@@ -1034,7 +1034,7 @@
             <tr>
               <td><code class="env-key">SECRET_KEY</code></td>
               <td><span class="env-required env-req-yes">Required</span></td>
-              <td>Cryptographic key for session signing and CSRF tokens. Generate with <code>openssl rand -hex 32</code>.</td>
+              <td>Cryptographic key for session signing, CSRF tokens, and confidential-identity encryption. <strong>Minimum 32 characters</strong> (the app refuses to start otherwise). Generate with <code>openssl rand -hex 32</code>.</td>
               <td>—</td>
             </tr>
             <tr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,68 +9,68 @@ authors = [{ name = "OpenWhistle Contributors" }]
 
 dependencies = [
     # Web framework
-    "fastapi>=0.136.0",
-    "uvicorn[standard]>=0.34.0",
-    "python-multipart>=0.0.20",
+    "fastapi>=0.139.0",
+    "uvicorn[standard]>=0.51.0",
+    "python-multipart>=0.0.32",
 
     # Database
-    "sqlalchemy[asyncio]>=2.0.49",
-    "asyncpg>=0.30.0",
-    "alembic>=1.14.0",
+    "sqlalchemy[asyncio]>=2.0.51",
+    "asyncpg>=0.31.0",
+    "alembic>=1.18.0",
 
     # Cache / Sessions
-    "redis[hiredis]>=5.2.0",
+    "redis[hiredis]>=8.0.0",
 
     # Auth
-    "authlib>=1.7.0",
-    "python-jose[cryptography]>=3.3.0",
-    "bcrypt>=4.3.0",
-    "pyotp>=2.9.0",
-    "qrcode[pil]>=8.0.0",
+    "authlib>=1.7.2",
+    "python-jose[cryptography]>=3.5.0",
+    "bcrypt>=5.0.0",
+    "pyotp>=2.10.0",
+    "qrcode[pil]>=8.2",
 
     # Configuration
-    "pydantic-settings>=2.7.0",
+    "pydantic-settings>=2.14.0",
 
     # Templates
-    "jinja2>=3.1.0",
-    "aiofiles>=24.1.0",
+    "jinja2>=3.1.6",
+    "aiofiles>=25.1.0",
 
     # Utilities
-    "httpx>=0.28.0",
-    "aiosmtplib>=3.0.0",
+    "httpx>=0.28.1",
+    "aiosmtplib>=5.1.0",
 
     # PDF generation (pure Python, no system packages required)
-    "fpdf2>=2.8.0",
+    "fpdf2>=2.8.7",
 
     # Structured logging
-    "python-json-logger>=3.2.0",
+    "python-json-logger>=4.1.0",
 
     # Background task scheduling (SLA reminders)
-    "apscheduler>=3.11.0",
+    "apscheduler>=3.11.3",
 
     # S3-compatible object storage (optional backend for attachments)
-    "boto3>=1.38.0",
+    "boto3>=1.43.0",
 
     # LDAP / Active Directory authentication (optional)
-    "ldap3>=2.9.0",
+    "ldap3>=2.9.1",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.3.0",
-    "pytest-asyncio>=0.25.0",
-    "pytest-cov>=6.0.0",
-    "mypy>=1.14.0",
-    "ruff>=0.9.0",
-    "types-aiofiles>=24.1.0",
+    "pytest>=9.1.0",
+    "pytest-asyncio>=1.4.0",
+    "pytest-cov>=7.1.0",
+    "mypy>=2.2.0",
+    "ruff>=0.15.0",
+    "types-aiofiles>=25.1.0",
 ]
 e2e = [
-    "playwright>=1.44.0",
-    "pytest-playwright>=0.5.0",
+    "playwright>=1.61.0",
+    "pytest-playwright>=0.8.0",
     "pytest-base-url>=2.1.0",
 ]
 perf = [
-    "locust>=2.27.0",
+    "locust>=2.45.0",
 ]
 
 [build-system]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -95,7 +95,12 @@ def run_axe(page: Page, axe_source: str) -> list[dict]:  # type: ignore[type-arg
     """
     if not axe_source:
         return []
-    page.add_script_tag(content=axe_source)
+    # Inject axe via page.evaluate (CDP Runtime.evaluate), NOT add_script_tag:
+    # a <script> element is subject to the page's strict CSP (no 'unsafe-inline'),
+    # whereas evaluate runs through the debugger protocol and is CSP-exempt.
+    # Wrap in an arrow body so the minified UMD runs regardless of whether its
+    # source is an expression or a series of statements.
+    page.evaluate("() => { " + axe_source + "\n; }")
     violations: list[dict] = page.evaluate(  # type: ignore[type-arg]
         """
         async () => {

--- a/tests/e2e/test_csp.py
+++ b/tests/e2e/test_csp.py
@@ -1,0 +1,95 @@
+"""End-to-end verification that the strict CSP does not break any page.
+
+A real browser is the only place inline-handler / inline-style / missing-nonce
+violations actually surface: the browser refuses the offending construct and
+emits a console error (and, for scripts, a pageerror) at load time. These tests
+load every significant page — and drive a couple of interactions — asserting
+that the console carries no Content-Security-Policy violation.
+
+Runs in the Playwright E2E CI job against the demo stack.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page
+
+_CSP_MARKERS = ("Content Security Policy", "Refused to", "violates the following")
+
+
+def _collect_violations(page: Page) -> list[str]:
+    hits: list[str] = []
+
+    def on_console(msg) -> None:  # type: ignore[no-untyped-def]
+        if msg.type == "error" and any(m in msg.text for m in _CSP_MARKERS):
+            hits.append(msg.text)
+
+    def on_pageerror(err) -> None:  # type: ignore[no-untyped-def]
+        text = str(err)
+        if any(m in text for m in _CSP_MARKERS):
+            hits.append(text)
+
+    page.on("console", on_console)
+    page.on("pageerror", on_pageerror)
+    return hits
+
+
+def _assert_clean(page: Page, url: str) -> None:
+    hits = _collect_violations(page)
+    page.goto(url)
+    page.wait_for_load_state("networkidle")
+    assert not hits, f"CSP violations on {url}:\n" + "\n".join(hits)
+
+
+def test_csp_public_pages(page: Page, base_url: str) -> None:
+    for path in ("/", "/submit", "/status", "/admin/login"):
+        _assert_clean(page, f"{base_url}{path}")
+
+
+def test_csp_theme_toggle_still_works(page: Page, base_url: str) -> None:
+    """The theme toggle used to be an inline onclick — verify the rewired
+    listener fires under CSP and no violation is logged."""
+    hits = _collect_violations(page)
+    page.goto(f"{base_url}/")
+    page.wait_for_load_state("networkidle")
+    before = page.get_attribute("html", "data-theme")
+    page.click("#theme-toggle")
+    after = page.get_attribute("html", "data-theme")
+    assert before != after, "theme toggle did not change the theme (handler blocked?)"
+    assert not hits, "CSP violations while toggling theme:\n" + "\n".join(hits)
+
+
+def test_csp_admin_pages(admin_page: Page, base_url: str) -> None:
+    for path in (
+        "/admin/dashboard",
+        "/admin/stats",
+        "/admin/users",
+        "/admin/categories",
+        "/admin/locations",
+        "/admin/audit-log",
+    ):
+        _assert_clean(admin_page, f"{base_url}{path}")
+
+
+def test_csp_admin_report_detail(admin_page: Page, base_url: str) -> None:
+    admin_page.goto(f"{base_url}/admin/dashboard")
+    admin_page.wait_for_load_state("networkidle")
+    link = admin_page.query_selector("a[href*='/admin/reports/']")
+    if not link:
+        return  # no reports seeded — nothing to check
+    href = link.get_attribute("href")
+    assert href
+    _assert_clean(admin_page, f"{base_url}{href}")
+
+
+def test_csp_submit_wizard_navigation(page: Page, base_url: str) -> None:
+    """The submit wizard used inline onclick/onchange for step navigation;
+    verify advancing a step raises no CSP violation."""
+    hits = _collect_violations(page)
+    page.goto(f"{base_url}/submit")
+    page.wait_for_load_state("networkidle")
+    # Advancing the first step exercises the rewired navigation handlers.
+    nxt = page.query_selector("button[type='submit'], .btn-primary")
+    if nxt:
+        nxt.click()
+        page.wait_for_load_state("networkidle")
+    assert not hits, "CSP violations in submit wizard:\n" + "\n".join(hits)

--- a/tests/test_bug_bounty_v111.py
+++ b/tests/test_bug_bounty_v111.py
@@ -1,0 +1,456 @@
+"""Bug-bounty regression tests — real defects found by an adversarial audit.
+
+Every test here targets a concrete bug that existed before the accompanying fix
+and would fail against the unpatched code. These are not coverage filler: each
+one pins down a specific wrong behaviour (data loss, auth bypass, crash, …).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_admin
+from app.main import app
+from app.models.report import ReportStatus
+from app.models.user import AdminRole, AdminUser
+
+# ── shared helpers ─────────────────────────────────────────────────────────
+
+
+def _user(role: AdminRole) -> AdminUser:
+    return AdminUser(
+        id=uuid.uuid4(),
+        username=f"{role.value}-{uuid.uuid4().hex[:8]}",
+        role=role,
+        is_active=True,
+        totp_secret="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        totp_enabled=True,
+    )
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def as_admin(client: AsyncClient):
+    def _set(user: AdminUser) -> None:
+        app.dependency_overrides[get_current_admin] = lambda: user
+
+    yield client, _set
+    app.dependency_overrides.pop(get_current_admin, None)
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def no_csrf():
+    from app.csrf import validate_csrf
+
+    app.dependency_overrides[validate_csrf] = lambda: None
+    yield
+    app.dependency_overrides.pop(validate_csrf, None)
+
+
+async def _mk_report(db: AsyncSession, description: str = "Bug bounty report body."):
+    from app.services.report import create_report
+
+    report, _ = await create_report(db, "financial_fraud", description)
+    return report
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# CRITICAL: reopened-then-reclosed report deleted on stale closure date
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_reopen_clears_closed_at_and_reclose_refreshes_it(db_session: AsyncSession) -> None:
+    from app.services.report import update_report_status
+
+    report = await _mk_report(db_session)
+    await update_report_status(db_session, report, ReportStatus.closed)
+    first = report.closed_at
+    assert first is not None
+
+    await update_report_status(db_session, report, ReportStatus.in_review)  # reopen
+    assert report.closed_at is None, "reopening must clear closed_at"
+
+    await update_report_status(db_session, report, ReportStatus.closed)  # re-close
+    assert report.closed_at is not None
+    assert report.closed_at >= first, "re-close must stamp a fresh closure time"
+
+
+@pytest.mark.asyncio
+async def test_direct_double_close_keeps_original_timestamp(db_session: AsyncSession) -> None:
+    """The fix must not regress the existing invariant: a direct re-close without
+    a reopen keeps the first closure timestamp."""
+    from app.services.report import update_report_status
+
+    report = await _mk_report(db_session)
+    await update_report_status(db_session, report, ReportStatus.closed)
+    first = report.closed_at
+    await update_report_status(db_session, report, ReportStatus.closed)
+    assert report.closed_at == first
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: acknowledge must be idempotent (statutory deadline not resettable)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_is_idempotent(db_session: AsyncSession) -> None:
+    from app.services.report import acknowledge_report
+
+    report = await _mk_report(db_session)
+    await acknowledge_report(db_session, report)
+    first_due = report.feedback_due_at
+    first_ack = report.acknowledged_at
+    assert first_due is not None
+
+    await acknowledge_report(db_session, report)  # second call must be a no-op
+    assert report.feedback_due_at == first_due
+    assert report.acknowledged_at == first_ack
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# MEDIUM: empty decrypted description must not fall back to ciphertext
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_empty_description_decrypts_to_empty_not_ciphertext(db_session: AsyncSession) -> None:
+    from app.services.report import create_report, decrypt_report_fields
+
+    report, _ = await create_report(db_session, "financial_fraud", "")
+    description, _ = decrypt_report_fields(report)
+    assert description == "", "empty plaintext must not be replaced by raw ciphertext"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: concurrent case-number collision must be retried, not 500
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_create_report_retries_on_case_number_collision(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services import report as report_svc
+
+    # Occupy a case number, then force generate_case_number to hand out that
+    # same (taken) number first, then a fresh one — the retry must recover.
+    taken = await _mk_report(db_session)
+    fresh_number = f"OW-9999-{uuid.uuid4().int % 100000:05d}"
+    seq = iter([taken.case_number, fresh_number])
+
+    async def fake_gen(_db):  # noqa: ANN001
+        return next(seq)
+
+    monkeypatch.setattr(report_svc, "generate_case_number", fake_gen)
+    report, _ = await report_svc.create_report(db_session, "financial_fraud", "Collision test.")
+    assert report.case_number == fresh_number
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: reminder dedup TTL must cover the warn window
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_reminder_dedup_ttl_covers_warn_windows() -> None:
+    from app.config import settings
+    from app.services.reminders import _dedup_ttl_seconds
+
+    # Entering the ack window (days_left == warn days) must suppress re-reminders
+    # for at least the remaining window, not just one scheduler hour.
+    assert _dedup_ttl_seconds(settings.reminder_ack_warn_days) > 3600
+    assert _dedup_ttl_seconds(settings.reminder_feedback_warn_days) >= (
+        settings.reminder_feedback_warn_days * 86400
+    )
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# CRITICAL: non-Latin-1 attachment filename must not break the download header
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_content_disposition_handles_non_latin1_filename() -> None:
+    from app.services.attachment import content_disposition_attachment
+
+    header = content_disposition_attachment("报告.pdf")
+    # The whole header value must be latin-1 encodable (Starlette requirement).
+    header.encode("latin-1")
+    assert "filename*=UTF-8''" in header
+    assert "%E6" in header.upper()  # percent-encoded CJK bytes present
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: PDF export must not crash on a non-Latin-1 note author (LDAP/OIDC name)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_pdf_export_survives_non_latin1_note_author(db_session: AsyncSession) -> None:
+    from app.services.pdf import generate_report_pdf
+    from app.services.report import add_note, get_report_by_id
+    from app.services.users import create_user
+
+    report = await _mk_report(db_session)
+    author, _ = await create_user(
+        db_session, f"noter-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    author.username = "王芳"  # simulates a directory-provisioned display name
+    await add_note(db_session, report, author, "Note from a unicode-named admin.")
+    loaded = await get_report_by_id(db_session, report.id)
+    assert loaded is not None
+
+    pdf_bytes = generate_report_pdf(loaded)
+    assert isinstance(pdf_bytes, bytes) and len(pdf_bytes) > 0
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: attachment upload — bounded read + count-before-read
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_upload_read_is_bounded() -> None:
+    from app.services.attachment import MAX_SIZE_BYTES, read_upload_files
+
+    upload = MagicMock()
+    upload.filename = "huge.pdf"
+    upload.content_type = "application/pdf"
+    upload.read = AsyncMock(return_value=b"X" * (MAX_SIZE_BYTES + 1))
+
+    _result, error = await read_upload_files([upload])
+    assert error is not None  # rejected as too large
+    upload.read.assert_awaited_once_with(MAX_SIZE_BYTES + 1)
+
+
+@pytest.mark.asyncio
+async def test_upload_count_limit_stops_reading_extra_files() -> None:
+    from app.services.attachment import MAX_ATTACHMENTS, read_upload_files
+
+    uploads = []
+    for i in range(MAX_ATTACHMENTS + 1):
+        u = MagicMock()
+        u.filename = f"f{i}.pdf"
+        u.content_type = "application/pdf"
+        u.read = AsyncMock(return_value=b"X" * 100)
+        uploads.append(u)
+
+    _result, error = await read_upload_files(uploads)
+    assert error is not None
+    uploads[MAX_ATTACHMENTS].read.assert_not_called()  # the extra file is never read
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# MEDIUM: case-insensitive duplicate usernames blocked
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_username_lookup_is_case_insensitive(db_session: AsyncSession) -> None:
+    from app.services.users import create_user, get_user_by_username_ci
+
+    uname = f"Bounty-{uuid.uuid4().hex[:6]}"
+    await create_user(db_session, uname, "TestPassword123!", AdminRole.admin)
+    found = await get_user_by_username_ci(db_session, uname.upper())
+    assert found is not None, "a case-variant of an existing username must be found"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# MEDIUM: relinking already-linked reports is detectable (→ clean 409)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_get_link_between_is_order_independent(db_session: AsyncSession) -> None:
+    from app.services.report import get_link_between, link_cases
+    from app.services.users import create_user
+
+    a = await _mk_report(db_session)
+    b = await _mk_report(db_session)
+    actor, _ = await create_user(
+        db_session, f"lk-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    await link_cases(db_session, a, b, actor)
+    # Order-independent detection is what lets the API return 409 instead of 500.
+    assert await get_link_between(db_session, a.id, b.id) is not None
+    assert await get_link_between(db_session, b.id, a.id) is not None
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# CRITICAL / HIGH: admin-user management authz (API level)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_deactivate_a_superadmin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    actor, _ = await create_user(
+        db_session, f"a-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    sa, _ = await create_user(
+        db_session, f"s-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    set_user(actor)
+    resp = await client.post(f"/admin/users/{sa.id}/deactivate", data={}, follow_redirects=False)
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_cannot_deactivate_last_privileged_admin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import (
+        count_active_privileged_admins,
+        create_user,
+        deactivate_user,
+        get_all_users,
+    )
+
+    for u in await get_all_users(db_session):
+        if u.role in (AdminRole.admin, AdminRole.superadmin) and u.is_active:
+            await deactivate_user(db_session, u)
+    sole, _ = await create_user(
+        db_session, f"sole-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    await db_session.commit()
+    if await count_active_privileged_admins(db_session) != 1:
+        pytest.skip("could not reduce to one privileged admin")
+
+    set_user(sole)
+    # sole tries to deactivate... another superadmin that we make and then this
+    # is the only one — deactivating any privileged account that is the last one
+    # must fail. Here sole targets itself-equivalent: create a second, then it is
+    # the last after removing the first. Simpler: sole cannot deactivate the only
+    # other privileged (none exists) — so target sole via a second actor.
+    actor, _ = await create_user(
+        db_session, f"act-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    await deactivate_user(db_session, actor)  # back to exactly one active (sole)
+    await db_session.commit()
+    set_user(actor)  # authenticated (override bypasses is_active), acts on sole
+    resp = await client.post(f"/admin/users/{sole.id}/deactivate", data={}, follow_redirects=False)
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_cannot_assign_report_to_deactivated_admin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import create_user, deactivate_user
+
+    actor, _ = await create_user(
+        db_session, f"a-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    ghost, _ = await create_user(
+        db_session, f"g-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.case_manager
+    )
+    await deactivate_user(db_session, ghost)
+    report = await _mk_report(db_session)
+    set_user(actor)
+    resp = await client.post(
+        f"/admin/reports/{report.id}/assign",
+        data={"admin_id": str(ghost.id)},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_linked_report_metadata_hidden_from_unauthorized_case_manager(
+    db_session: AsyncSession, as_admin
+) -> None:
+    client, set_user = as_admin
+    from app.services.report import assign_report, link_cases
+    from app.services.users import create_user
+
+    a = await _mk_report(db_session)
+    b = await _mk_report(db_session)  # b.case_number is the secret we must not leak
+    admin, _ = await create_user(
+        db_session, f"ad-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    cm1, _ = await create_user(
+        db_session, f"c1-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.case_manager
+    )
+    cm2, _ = await create_user(
+        db_session, f"c2-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.case_manager
+    )
+    await assign_report(db_session, a, cm1)
+    await assign_report(db_session, b, cm2)
+    await link_cases(db_session, a, b, admin)
+
+    set_user(cm1)
+    resp = await client.get(f"/admin/reports/{a.id}", follow_redirects=False)
+    assert resp.status_code == 200
+    assert b.case_number not in resp.text  # cm1 is not authorized on report b
+
+
+@pytest.mark.asyncio
+async def test_download_non_latin1_filename_does_not_500(
+    db_session: AsyncSession, as_admin
+) -> None:
+    client, set_user = as_admin
+    from app.models.attachment import Attachment
+
+    report = await _mk_report(db_session)
+    att = Attachment(
+        id=uuid.uuid4(),
+        report_id=report.id,
+        filename="报告.pdf",
+        content_type="application/pdf",
+        size=4,
+        data=b"TEST",
+    )
+    db_session.add(att)
+    await db_session.commit()
+
+    set_user(_user(AdminRole.admin))
+    resp = await client.get(
+        f"/admin/reports/{report.id}/attachments/{att.id}", follow_redirects=False
+    )
+    assert resp.status_code == 200
+    assert resp.content == b"TEST"
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: SUBMISSION_MODE_ENABLED=false must force anonymous
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_confidential_rejected_when_submission_mode_disabled(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import re
+
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "submission_mode_enabled", False)
+
+    get_resp = await client.get("/submit")
+    m = re.search(r'name="csrf_token" value="([^"]+)"', get_resp.text)
+    csrf = m.group(1) if m else ""
+    resp = await client.post(
+        "/submit",
+        data={
+            "csrf_token": csrf,
+            "step": "1",
+            "action": "next",
+            "submission_mode": "confidential",
+            "confidential_name": "Jane Doe",
+            "secure_email": "jane@example.com",
+        },
+    )
+    # The identifying fields must not have been stored — the report is forced
+    # anonymous. The confidential name must not be echoed on the next step.
+    assert "Jane Doe" not in resp.text

--- a/tests/test_bug_bounty_v111.py
+++ b/tests/test_bug_bounty_v111.py
@@ -507,11 +507,16 @@ async def test_dashboard_hides_other_org_reports_from_orgless_admin(
     db_session: AsyncSession, as_admin, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from app.config import settings
+    from app.models.organisation import Organisation
 
     monkeypatch.setattr(settings, "multi_tenancy_enabled", True)
 
+    other_org = Organisation(id=uuid.uuid4(), name="Other Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    db_session.add(other_org)
+    await db_session.commit()
+
     report = await _mk_report(db_session)
-    report.org_id = uuid.uuid4()  # belongs to some other organisation
+    report.org_id = other_org.id  # belongs to some other organisation
     await db_session.commit()
 
     client, set_user = as_admin

--- a/tests/test_bug_bounty_v111.py
+++ b/tests/test_bug_bounty_v111.py
@@ -121,9 +121,13 @@ async def test_acknowledge_is_idempotent(db_session: AsyncSession) -> None:
 
 @pytest.mark.asyncio
 async def test_empty_description_decrypts_to_empty_not_ciphertext(db_session: AsyncSession) -> None:
-    from app.services.report import create_report, decrypt_report_fields
+    from app.services.report import create_report, decrypt_report_fields, get_report_by_id
 
-    report, _ = await create_report(db_session, "financial_fraud", "")
+    created, _ = await create_report(db_session, "financial_fraud", "")
+    # Reload with relationships eagerly loaded (decrypt_report_fields iterates
+    # report.messages, which would otherwise lazy-load in a sync context).
+    report = await get_report_by_id(db_session, created.id)
+    assert report is not None
     description, _ = decrypt_report_fields(report)
     assert description == "", "empty plaintext must not be replaced by raw ciphertext"
 
@@ -454,3 +458,66 @@ async def test_confidential_rejected_when_submission_mode_disabled(
     # The identifying fields must not have been stored — the report is forced
     # anonymous. The confidential name must not be echoed on the next step.
     assert "Jane Doe" not in resp.text
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# HIGH: whistleblower PIN lockout must not be bypassable by rotating the token
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_pin_lockout_keyed_on_case_number_not_session_token(
+    client: AsyncClient, no_csrf
+) -> None:
+    import re
+
+    from app.config import settings
+    from app.redis_client import get_redis
+    from app.services import rate_limit as rl
+
+    case = f"OW-2026-{uuid.uuid4().int % 100000:05d}"
+    # Guess repeatedly, minting a FRESH session_token before each attempt — the
+    # old bypass reset the counter every time the token changed.
+    for _ in range(settings.max_access_attempts + 1):
+        get_resp = await client.get("/status")
+        m = re.search(r'name="session_token" value="([^"]+)"', get_resp.text)
+        token = m.group(1) if m else uuid.uuid4().hex
+        await client.post(
+            "/status",
+            data={
+                "case_number": case,
+                "pin": "00000000-0000-0000-0000-000000000000",
+                "session_token": token,
+            },
+        )
+
+    redis = await get_redis()
+    # The lockout counter must have accumulated on the case number despite the
+    # rotating tokens, so further guesses are now blocked.
+    assert await rl.check_whistleblower_attempts(redis, case.upper()) is False
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# MEDIUM: org-less non-superadmin must not see other tenants' reports in list
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.asyncio
+async def test_dashboard_hides_other_org_reports_from_orgless_admin(
+    db_session: AsyncSession, as_admin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "multi_tenancy_enabled", True)
+
+    report = await _mk_report(db_session)
+    report.org_id = uuid.uuid4()  # belongs to some other organisation
+    await db_session.commit()
+
+    client, set_user = as_admin
+    admin = _user(AdminRole.admin)  # org_id is None
+    admin.org_id = None
+    set_user(admin)
+    resp = await client.get("/admin/dashboard", follow_redirects=False)
+    assert resp.status_code == 200
+    assert report.case_number not in resp.text

--- a/tests/test_bug_bounty_v111.py
+++ b/tests/test_bug_bounty_v111.py
@@ -526,3 +526,120 @@ async def test_dashboard_hides_other_org_reports_from_orgless_admin(
     resp = await client.get("/admin/dashboard", follow_redirects=False)
     assert resp.status_code == 200
     assert report.case_number not in resp.text
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# WAVE 3 — maximal pass (incl. breaking config change)
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_secret_key_minimum_length_enforced() -> None:
+    from app.config import Settings
+
+    with pytest.raises(ValueError, match="SECRET_KEY"):
+        Settings(secret_key="short")  # type: ignore[call-arg]
+    # A sufficiently long key is accepted.
+    ok = Settings(secret_key="x" * 32)  # type: ignore[call-arg]
+    assert ok.secret_key == "x" * 32
+
+
+def test_decrypt_or_none_logs_on_tampered_token(caplog: pytest.LogCaptureFixture) -> None:
+    from app.services.crypto import decrypt_or_none
+
+    with caplog.at_level("WARNING"):
+        assert decrypt_or_none("gAAAAA-not-a-valid-fernet-token") is None
+    assert any("decrypt" in r.message.lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_submit_post_rejects_unknown_client_session_id(
+    client: AsyncClient, no_csrf
+) -> None:
+    client.cookies.set("ow-submission-session", "attacker-chosen-id-000001")
+    resp = await client.post(
+        "/submit",
+        data={"step": "1", "action": "next", "submission_mode": "anonymous"},
+    )
+    # The server must not persist state under an id it never issued.
+    assert resp.cookies.get("ow-submission-session") not in (None, "attacker-chosen-id-000001")
+
+
+@pytest.mark.asyncio
+async def test_submit_post_rejects_jump_to_attachment_step(client: AsyncClient) -> None:
+    resp = await client.get("/submit")
+    import re
+
+    m = re.search(r'name="csrf_token" value="([^"]+)"', resp.text)
+    csrf = m.group(1) if m else ""
+    # Jump straight to step 5 (attachments) on a fresh session.
+    jump = await client.post(
+        "/submit",
+        data={"csrf_token": csrf, "step": "5", "action": "next"},
+    )
+    # Must bounce back to the mode step, not advance to review (step 6).
+    assert 'name="step" value="6"' not in jump.text
+
+
+@pytest.mark.asyncio
+async def test_totp_code_cannot_be_replayed_across_sessions(
+    client: AsyncClient, db_session: AsyncSession, no_csrf
+) -> None:
+    import pyotp
+
+    from app.redis_client import get_redis
+    from app.services import auth as auth_service
+    from app.services.users import create_user
+
+    secret = pyotp.random_base32()
+    user, _ = await create_user(
+        db_session, f"totp-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    user.totp_secret = secret
+    user.totp_enabled = True
+    await db_session.commit()
+
+    redis = await get_redis()
+    code = pyotp.TOTP(secret).now()
+
+    temp1 = uuid.uuid4().hex
+    await auth_service.store_totp_pending(redis, temp1, str(user.id))
+    r1 = await client.post(
+        "/admin/login/mfa", data={"totp_code": code, "temp_token": temp1}, follow_redirects=False
+    )
+    assert r1.status_code == 302  # first use succeeds
+
+    temp2 = uuid.uuid4().hex
+    await auth_service.store_totp_pending(redis, temp2, str(user.id))
+    r2 = await client.post(
+        "/admin/login/mfa", data={"totp_code": code, "temp_token": temp2}, follow_redirects=False
+    )
+    assert r2.status_code != 302  # replay of the same code must be rejected
+
+
+@pytest.mark.asyncio
+async def test_retention_cleanup_skipped_when_lock_held(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    from app.config import settings
+    from app.redis_client import get_redis
+    from app.services.report import get_report_by_id
+    from app.services.retention import run_retention_cleanup
+
+    monkeypatch.setattr(settings, "retention_enabled", True)
+
+    report = await _mk_report(db_session)
+    report.status = ReportStatus.closed
+    report.closed_at = datetime.now(UTC) - timedelta(days=settings.retention_days + 10)
+    await db_session.commit()
+
+    # Simulate another replica already holding the job lock.
+    redis = await get_redis()
+    await redis.set("openwhistle:job_lock:retention", "1", nx=True, ex=3600)
+    try:
+        await run_retention_cleanup()
+        # Lock held → this run is skipped → the eligible report survives.
+        assert await get_report_by_id(db_session, report.id) is not None
+    finally:
+        await redis.delete("openwhistle:job_lock:retention")

--- a/tests/test_bug_bounty_v111.py
+++ b/tests/test_bug_bounty_v111.py
@@ -582,13 +582,18 @@ async def test_submit_post_rejects_jump_to_attachment_step(client: AsyncClient) 
 
 @pytest.mark.asyncio
 async def test_totp_code_cannot_be_replayed_across_sessions(
-    client: AsyncClient, db_session: AsyncSession, no_csrf
+    client: AsyncClient, db_session: AsyncSession, no_csrf, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import pyotp
 
+    from app.config import settings
     from app.redis_client import get_redis
     from app.services import auth as auth_service
     from app.services.users import create_user
+
+    # CI runs with DEMO_MODE=true, which intentionally makes the static code
+    # reusable; force it off so the one-time-use path is exercised.
+    monkeypatch.setattr(settings, "demo_mode", False)
 
     secret = pyotp.random_base32()
     user, _ = await create_user(
@@ -622,8 +627,9 @@ async def test_retention_cleanup_skipped_when_lock_held(
 ) -> None:
     from datetime import UTC, datetime, timedelta
 
+    from redis.asyncio import Redis
+
     from app.config import settings
-    from app.redis_client import get_redis
     from app.services.report import get_report_by_id
     from app.services.retention import run_retention_cleanup
 
@@ -634,12 +640,16 @@ async def test_retention_cleanup_skipped_when_lock_held(
     report.closed_at = datetime.now(UTC) - timedelta(days=settings.retention_days + 10)
     await db_session.commit()
 
-    # Simulate another replica already holding the job lock.
-    redis = await get_redis()
-    await redis.set("openwhistle:job_lock:retention", "1", nx=True, ex=3600)
+    # Simulate another replica already holding the job lock. Use a dedicated
+    # connection (not the shared request-scoped client) to avoid binding it to
+    # this test's event loop.
+    lock_redis = Redis.from_url(settings.redis_url)
+    await lock_redis.set("openwhistle:job_lock:retention", "1", nx=True, ex=600)
     try:
         await run_retention_cleanup()
-        # Lock held → this run is skipped → the eligible report survives.
+        # Lock held by "another replica" → this run is skipped (and must NOT
+        # release a lock it does not own) → the eligible report survives.
         assert await get_report_by_id(db_session, report.id) is not None
     finally:
-        await redis.delete("openwhistle:job_lock:retention")
+        await lock_redis.delete("openwhistle:job_lock:retention")
+        await lock_redis.aclose()

--- a/tests/test_csp_no_inline.py
+++ b/tests/test_csp_no_inline.py
@@ -1,0 +1,67 @@
+"""Structural guard: templates must contain no CSP-'unsafe-inline' constructs.
+
+The application ships a strict, nonce-based Content-Security-Policy with no
+'unsafe-inline' in script-src or style-src (GHSA-gh23-4h5j-cqj8, finding #1).
+Under that policy the browser silently drops:
+
+  * inline event-handler attributes  (onclick="…", onchange="…", …)
+  * inline style attributes           (style="…")
+  * <script>/<style> blocks without the matching per-response nonce
+
+Any of those would break the page at runtime. This test fails the build if a
+template reintroduces one, so a regression cannot ship unnoticed — a real
+browser only exercises the pages a test happens to visit, whereas this covers
+every template deterministically.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "app" / "templates"
+_TEMPLATES = sorted(_TEMPLATE_DIR.rglob("*.html"))
+
+# Inline event-handler attributes: on<name>= not preceded by a word char
+# (so it never matches e.g. "person=" or Jinja tokens).
+_INLINE_HANDLER_RE = re.compile(r"(?<![\w-])on[a-z]+\s*=", re.IGNORECASE)
+_INLINE_STYLE_RE = re.compile(r'(?<![\w-])style\s*=\s*["\']')
+# A <script>/<style> opening tag. We then require a nonce attribute on it.
+_OPEN_TAG_RE = re.compile(r"<(script|style)(\s[^>]*)?>", re.IGNORECASE)
+_NONCE_ATTR = "nonce="
+
+
+def test_templates_exist() -> None:
+    assert _TEMPLATES, "no templates found — path wrong?"
+
+
+@pytest.mark.parametrize("tpl", _TEMPLATES, ids=lambda p: p.name)
+def test_no_inline_event_handlers(tpl: Path) -> None:
+    text = tpl.read_text(encoding="utf-8")
+    hits = [m.group(0) for m in _INLINE_HANDLER_RE.finditer(text)]
+    assert not hits, f"{tpl.name}: inline event handler(s) forbidden under CSP: {hits}"
+
+
+@pytest.mark.parametrize("tpl", _TEMPLATES, ids=lambda p: p.name)
+def test_no_inline_style_attributes(tpl: Path) -> None:
+    text = tpl.read_text(encoding="utf-8")
+    hits = _INLINE_STYLE_RE.findall(text)
+    assert not hits, (
+        f"{tpl.name}: {len(hits)} inline style attribute(s) forbidden under CSP — "
+        "move them into a nonce'd <style> block or a CSS class"
+    )
+
+
+@pytest.mark.parametrize("tpl", _TEMPLATES, ids=lambda p: p.name)
+def test_script_and_style_blocks_carry_nonce(tpl: Path) -> None:
+    text = tpl.read_text(encoding="utf-8")
+    offenders: list[str] = []
+    for m in _OPEN_TAG_RE.finditer(text):
+        attrs = (m.group(2) or "")
+        if _NONCE_ATTR not in attrs:
+            offenders.append(m.group(0)[:60])
+    assert not offenders, (
+        f"{tpl.name}: <script>/<style> block(s) without a CSP nonce: {offenders}"
+    )

--- a/tests/test_security_advisories_v111.py
+++ b/tests/test_security_advisories_v111.py
@@ -525,8 +525,13 @@ async def test_create_user_invalid_role_falls_back_to_admin_not_superadmin(
     """A garbage role value must never silently become superadmin."""
     client, set_user = as_admin
     from app.services.auth import get_user_by_username
+    from app.services.users import create_user
 
-    set_user(_user(AdminRole.admin))
+    # Success path writes an audit row (FK on audit_logs.admin_id) → persist actor.
+    actor, _ = await create_user(
+        db_session, f"act-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    set_user(actor)
     uname = f"fallback-{uuid.uuid4().hex[:6]}"
     resp = await client.post(
         "/admin/users",

--- a/tests/test_security_advisories_v111.py
+++ b/tests/test_security_advisories_v111.py
@@ -318,3 +318,311 @@ async def test_security_headers_single_and_consistent(client: AsyncClient) -> No
     hsts = resp.headers.get("Strict-Transport-Security", "")
     assert hsts.count("max-age=") == 1
     assert "server" not in {k.lower() for k in resp.headers}
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Adversarial edge cases — think like an attacker probing every mutating path
+# and every privilege boundary, not just the happy path.
+# ══════════════════════════════════════════════════════════════════════════
+
+
+# ── GHSA-q3v3: IDOR must hold on EVERY report action, not just detail ──────
+
+
+@pytest.mark.parametrize(
+    ("method", "path_suffix", "data"),
+    [
+        ("post", "/acknowledge", {}),
+        ("post", "/status", {"new_status": "acknowledged"}),
+        ("post", "/reply", {"content": "sneaky reply"}),
+        ("post", "/notes", {"content": "sneaky note"}),
+        ("get", "/export.pdf", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_case_manager_blocked_from_every_unassigned_action(
+    db_session: AsyncSession, as_admin, no_csrf, method: str, path_suffix: str, data
+) -> None:
+    """A case manager must get 404 on read AND write actions for reports not theirs."""
+    client, set_user = as_admin
+    report = await _make_confidential_report(db_session, assigned_to_id=None)
+    set_user(_user(AdminRole.case_manager))
+
+    url = f"/admin/reports/{report.id}{path_suffix}"
+    if method == "post":
+        resp = await client.post(url, data=data, follow_redirects=False)
+    else:
+        resp = await client.get(url, follow_redirects=False)
+    assert resp.status_code == 404, f"{method} {path_suffix} leaked (status {resp.status_code})"
+
+
+@pytest.mark.asyncio
+async def test_assigned_case_manager_can_acknowledge(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    """Positive counterpart: the assigned case manager CAN act on their report."""
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    cm, _ = await create_user(
+        db_session, f"cm-{uuid.uuid4().hex[:8]}", "TestPassword123!", AdminRole.case_manager
+    )
+    report = await _make_confidential_report(db_session, assigned_to_id=cm.id)
+    set_user(cm)
+    resp = await client.post(
+        f"/admin/reports/{report.id}/acknowledge", data={}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+
+
+@pytest.mark.asyncio
+async def test_admin_may_read_unassigned_report_single_tenant(
+    db_session: AsyncSession, as_admin
+) -> None:
+    """Regression: single-tenant admins are NOT restricted to assigned reports."""
+    client, set_user = as_admin
+    report = await _make_confidential_report(db_session, assigned_to_id=None)
+    set_user(_user(AdminRole.admin))
+    resp = await client.get(f"/admin/reports/{report.id}", follow_redirects=False)
+    assert resp.status_code == 200
+    # An admin legitimately sees the confidential identity even when unassigned.
+    assert "REALNAME-CANARY" in resp.text
+
+
+# ── GHSA-g3xj: escalation guards from every angle ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_promote_another_admin_to_superadmin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    actor, _ = await create_user(
+        db_session, f"a-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    victim, _ = await create_user(
+        db_session, f"v-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    set_user(actor)
+    resp = await client.post(
+        f"/admin/users/{victim.id}/role", data={"role": "superadmin"}, follow_redirects=False
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_demote_a_superadmin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    """An admin must not be able to touch a superadmin's role at all."""
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    actor, _ = await create_user(
+        db_session, f"a-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    sa, _ = await create_user(
+        db_session, f"s-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    set_user(actor)
+    resp = await client.post(
+        f"/admin/users/{sa.id}/role", data={"role": "admin"}, follow_redirects=False
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_superadmin_cannot_change_own_role(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    """The self-role-change ban applies to superadmins too (no self-demotion foot-gun)."""
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    sa, _ = await create_user(
+        db_session, f"s-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    set_user(sa)
+    resp = await client.post(
+        f"/admin/users/{sa.id}/role", data={"role": "admin"}, follow_redirects=False
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_can_change_another_admin_to_case_manager(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    """Legitimate downward role change within an admin's authority still works."""
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    actor, _ = await create_user(
+        db_session, f"a-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    # Two more admins so demoting one does not trip the last-admin guard.
+    await create_user(db_session, f"a2-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin)
+    victim, _ = await create_user(
+        db_session, f"v-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.admin
+    )
+    set_user(actor)
+    resp = await client.post(
+        f"/admin/users/{victim.id}/role", data={"role": "case_manager"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+
+
+@pytest.mark.asyncio
+async def test_cannot_demote_last_privileged_admin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    """Availability invariant: the last admin/superadmin cannot be demoted away."""
+    client, set_user = as_admin
+    from app.services.users import (
+        count_active_privileged_admins,
+        create_user,
+        deactivate_user,
+        get_all_users,
+    )
+
+    # Reduce the instance to exactly one active privileged account.
+    for u in await get_all_users(db_session):
+        if u.role in (AdminRole.admin, AdminRole.superadmin) and u.is_active:
+            await deactivate_user(db_session, u)
+    sole, _ = await create_user(
+        db_session, f"sole-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    await db_session.commit()
+    if await count_active_privileged_admins(db_session) != 1:
+        pytest.skip("could not reduce to a single privileged admin")
+
+    # A second superadmin performs the (forbidden) demotion so the self-check
+    # and tier-check do not fire first.
+    actor, _ = await create_user(
+        db_session, f"act-{uuid.uuid4().hex[:6]}", "TestPassword123!", AdminRole.superadmin
+    )
+    # actor is now also privileged+active → temporarily there are 2; deactivate
+    # actor's privilege effect by testing demotion of `sole` while only `sole`
+    # counts. Re-assert the count with actor present:
+    set_user(actor)
+    # With actor active there are 2 privileged admins, so demoting `sole` is allowed.
+    # Deactivate actor to leave `sole` as the only one, then have a superadmin
+    # (actor, still authenticated) attempt it — count is 1 → must be blocked.
+    await deactivate_user(db_session, actor)
+    await db_session.commit()
+    resp = await client.post(
+        f"/admin/users/{sole.id}/role", data={"role": "case_manager"}, follow_redirects=False
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_user_invalid_role_falls_back_to_admin_not_superadmin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    """A garbage role value must never silently become superadmin."""
+    client, set_user = as_admin
+    from app.services.auth import get_user_by_username
+
+    set_user(_user(AdminRole.admin))
+    uname = f"fallback-{uuid.uuid4().hex[:6]}"
+    resp = await client.post(
+        "/admin/users",
+        data={"username": uname, "password": "TestPassword123!", "role": "root"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+    created = await get_user_by_username(db_session, uname)
+    assert created is not None
+    assert created.role == AdminRole.admin
+
+
+# ── GHSA-24hg: username validation — boundaries and injection payloads ─────
+
+
+@pytest.mark.parametrize("name", ["abc", "a" * 64, "a.b", "a-b", "a_b", "a@b.co", "A B"])
+def test_validate_username_boundaries_ok(name: str) -> None:
+    assert validate_username(name) == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ab",                         # 2 chars (below min)
+        "a" * 65,                     # 65 chars (above max)
+        "",                           # empty
+        "   ",                        # whitespace-only
+        "a\nb",                       # newline injection
+        "a\tb",                       # tab
+        "a\x00b",                     # null byte
+        "аdmin",                      # cyrillic homoglyph 'а'
+        "a<b",                        # angle bracket
+        "a>b",
+        'a"b',
+        "a'b",
+        "a/b",
+        "a\\b",
+        "a;b",
+        "a`b",
+        "a${b}",
+        "a%27b",
+    ],
+)
+def test_validate_username_rejects_injection_and_boundaries(name: str) -> None:
+    with pytest.raises(ValueError):
+        validate_username(name)
+
+
+def test_validate_username_strips_surrounding_whitespace() -> None:
+    assert validate_username("  alice  ") == "alice"
+
+
+# ── GHSA-gh23: the CSP itself — strict, nonce-based, unique per request ────
+
+
+@pytest.mark.asyncio
+async def test_csp_is_strict_and_nonce_based(client: AsyncClient) -> None:
+    resp = await client.get("/admin/login")
+    csp = resp.headers.get("Content-Security-Policy", "")
+    assert csp, "no CSP header"
+    assert "unsafe-inline" not in csp, "CSP still allows unsafe-inline"
+    assert "unsafe-eval" not in csp
+    assert "script-src 'self' 'nonce-" in csp
+    assert "style-src 'self' 'nonce-" in csp
+    assert "object-src 'none'" in csp
+    assert "base-uri 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+    # httpx would join duplicate headers with ", "; a single policy has none of that.
+    assert csp.count("default-src") == 1
+
+
+@pytest.mark.asyncio
+async def test_csp_nonce_is_unique_per_response(client: AsyncClient) -> None:
+    import re
+
+    def nonce_of(csp: str) -> str:
+        m = re.search(r"'nonce-([^']+)'", csp)
+        return m.group(1) if m else ""
+
+    r1 = await client.get("/admin/login")
+    r2 = await client.get("/admin/login")
+    n1 = nonce_of(r1.headers.get("Content-Security-Policy", ""))
+    n2 = nonce_of(r2.headers.get("Content-Security-Policy", ""))
+    assert n1 and n2 and n1 != n2, "CSP nonce must differ per response"
+
+
+@pytest.mark.asyncio
+async def test_rendered_html_uses_the_header_nonce(client: AsyncClient) -> None:
+    """The nonce in the CSP header must match the nonce on inline blocks, or
+    the browser would drop every inline script/style."""
+    import re
+
+    resp = await client.get("/admin/login")
+    csp = resp.headers.get("Content-Security-Policy", "")
+    m = re.search(r"'nonce-([^']+)'", csp)
+    assert m, "no nonce in CSP"
+    nonce = m.group(1)
+    # The login page extends base.html, which has nonce'd <script>/<style> blocks.
+    assert f'nonce="{nonce}"' in resp.text

--- a/tests/test_security_advisories_v111.py
+++ b/tests/test_security_advisories_v111.py
@@ -1,0 +1,320 @@
+"""Regression tests for the v1.1.1 security advisories.
+
+Covers:
+- GHSA-q3v3-5xf4-xjqr — missing object-level authorization on /admin/reports/{id}
+  (case manager / cross-org report access & confidential-identity deanonymization).
+- GHSA-g3xj-3929-r45h — vertical privilege escalation via the role-assignment
+  endpoints (admin self-promotes to superadmin / creates a superadmin).
+- GHSA-24hg-pf84-jj7x — username charset validation (defense-in-depth for the
+  stored-XSS-in-onclick sink, which is additionally fixed at the template layer).
+- GHSA-gh23-4h5j-cqj8 — security headers emitted by a single authoritative layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.admin import _can_access_report
+from app.api.deps import get_current_admin
+from app.main import app
+from app.models.report import SubmissionMode
+from app.models.user import AdminRole, AdminUser
+from app.services import crypto
+from app.services import report as report_service
+from app.services.users import validate_username
+
+
+def _user(role: AdminRole, org_id: uuid.UUID | None = None) -> AdminUser:
+    """Build a detached AdminUser carrying only the attributes authz reads."""
+    return AdminUser(
+        id=uuid.uuid4(),
+        username=f"{role.value}-{uuid.uuid4().hex[:8]}",
+        role=role,
+        org_id=org_id,
+        is_active=True,
+        totp_secret="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        totp_enabled=True,
+    )
+
+
+def _report(assigned_to_id: uuid.UUID | None, org_id: uuid.UUID | None = None):
+    from app.models.report import Report
+
+    return Report(id=uuid.uuid4(), assigned_to_id=assigned_to_id, org_id=org_id)
+
+
+# ── GHSA-q3v3: _can_access_report authorization matrix (unit) ──────────────
+
+
+def test_superadmin_can_access_any_report() -> None:
+    sa = _user(AdminRole.superadmin)
+    assert _can_access_report(sa, _report(assigned_to_id=uuid.uuid4())) is True
+
+
+def test_case_manager_only_assigned_reports() -> None:
+    cm = _user(AdminRole.case_manager)
+    assert _can_access_report(cm, _report(assigned_to_id=cm.id)) is True
+    assert _can_access_report(cm, _report(assigned_to_id=uuid.uuid4())) is False
+    assert _can_access_report(cm, _report(assigned_to_id=None)) is False
+
+
+def test_admin_can_access_reports_without_multitenancy() -> None:
+    admin = _user(AdminRole.admin)
+    # Assigned to someone else, but single-tenant → admin may access.
+    assert _can_access_report(admin, _report(assigned_to_id=uuid.uuid4())) is True
+
+
+def test_admin_org_scoping_with_multitenancy(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "multi_tenancy_enabled", True)
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+    admin = _user(AdminRole.admin, org_id=org_a)
+    assert _can_access_report(admin, _report(assigned_to_id=None, org_id=org_a)) is True
+    assert _can_access_report(admin, _report(assigned_to_id=None, org_id=org_b)) is False
+    # superadmin is exempt from org scoping.
+    sa = _user(AdminRole.superadmin, org_id=None)
+    assert _can_access_report(sa, _report(assigned_to_id=None, org_id=org_b)) is True
+
+
+# ── GHSA-24hg: username validation (unit) ──────────────────────────────────
+
+
+@pytest.mark.parametrize("name", ["alice", "case.manager", "a_b-c", "user@corp", "Bob Smith"])
+def test_validate_username_accepts_allowlist(name: str) -> None:
+    assert validate_username(name) == name.strip()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "a'+__XSS('x')+'",       # the advisory's breakout payload
+        "ab",                     # too short
+        "x" * 65,                 # too long
+        'quote"here',
+        "semi;colon",
+        "<script>",
+        "back\\slash",
+    ],
+)
+def test_validate_username_rejects_bad_input(name: str) -> None:
+    with pytest.raises(ValueError):
+        validate_username(name)
+
+
+# ── Integration fixtures: synthetic authenticated admin ────────────────────
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def as_admin(client: AsyncClient):
+    """Yield (client, setter) where setter(user) forces the current admin."""
+    def _set(user: AdminUser) -> None:
+        app.dependency_overrides[get_current_admin] = lambda: user
+
+    yield client, _set
+    app.dependency_overrides.pop(get_current_admin, None)
+
+
+async def _make_confidential_report(db: AsyncSession, assigned_to_id: uuid.UUID | None):
+    report, _pin = await report_service.create_report(
+        db,
+        category="financial_fraud",
+        description="A confidential report used for authorization tests.",
+        submission_mode=SubmissionMode.confidential,
+        confidential_name_enc=crypto.encrypt("REALNAME-CANARY"),
+        confidential_contact_enc=crypto.encrypt("CONTACT-CANARY"),
+    )
+    if assigned_to_id is not None:
+        report.assigned_to_id = assigned_to_id
+        await db.commit()
+        await db.refresh(report)
+    return report
+
+
+# ── GHSA-q3v3: endpoint-level authorization (integration) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_case_manager_cannot_open_unassigned_report(
+    db_session: AsyncSession, as_admin
+) -> None:
+    client, set_user = as_admin
+    report = await _make_confidential_report(db_session, assigned_to_id=None)
+
+    cm = _user(AdminRole.case_manager)
+    set_user(cm)
+    resp = await client.get(f"/admin/reports/{report.id}", follow_redirects=False)
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_case_manager_sees_identity_only_when_assigned(
+    db_session: AsyncSession, as_admin
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    # The assignee must be a real row (FK on reports.assigned_to_id).
+    cm, _ = await create_user(
+        db_session, f"cm-{uuid.uuid4().hex[:8]}", "TestPassword123!", AdminRole.case_manager
+    )
+    report = await _make_confidential_report(db_session, assigned_to_id=cm.id)
+
+    set_user(cm)
+    resp = await client.get(f"/admin/reports/{report.id}", follow_redirects=False)
+    assert resp.status_code == 200
+    assert "REALNAME-CANARY" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_case_manager_cannot_add_note_to_unassigned_report(
+    db_session: AsyncSession, as_admin
+) -> None:
+    client, set_user = as_admin
+    report = await _make_confidential_report(db_session, assigned_to_id=None)
+
+    cm = _user(AdminRole.case_manager)
+    set_user(cm)
+    # CSRF is enforced separately; a missing/invalid token would 4xx before authz,
+    # so we assert the authz 404 by hitting the GET-guarded attachment path.
+    resp = await client.get(
+        f"/admin/reports/{report.id}/attachments/{uuid.uuid4()}",
+        follow_redirects=False,
+    )
+    assert resp.status_code == 404
+
+
+# ── GHSA-g3xj: privilege-escalation guards (integration) ───────────────────
+
+
+def _csrf_bypass():
+    """Disable CSRF validation so we can test authz in isolation."""
+    from app.csrf import validate_csrf
+
+    app.dependency_overrides[validate_csrf] = lambda: None
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def no_csrf():
+    _csrf_bypass()
+    yield
+    from app.csrf import validate_csrf
+
+    app.dependency_overrides.pop(validate_csrf, None)
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_self_promote_to_superadmin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    admin, _ = await create_user(db_session, "plainadmin", "TestPassword123!", AdminRole.admin)
+    set_user(admin)
+    resp = await client.post(
+        f"/admin/users/{admin.id}/role",
+        data={"role": "superadmin"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_change_own_role(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    client, set_user = as_admin
+    from app.services.users import create_user
+
+    admin, _ = await create_user(db_session, "selfrole", "TestPassword123!", AdminRole.admin)
+    set_user(admin)
+    resp = await client.post(
+        f"/admin/users/{admin.id}/role",
+        data={"role": "case_manager"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_admin_cannot_create_superadmin(
+    client: AsyncClient, as_admin, no_csrf
+) -> None:
+    _client, set_user = as_admin
+    set_user(_user(AdminRole.admin))
+    resp = await _client.post(
+        "/admin/users",
+        data={
+            "username": "wannabe-super",
+            "password": "TestPassword123!",
+            "role": "superadmin",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_superadmin_can_create_superadmin(
+    db_session: AsyncSession, as_admin, no_csrf
+) -> None:
+    _client, set_user = as_admin
+    from app.services.users import create_user
+
+    # The acting superadmin writes an audit row (FK on audit_logs.admin_id),
+    # so it must be a persisted user.
+    actor, _ = await create_user(
+        db_session, f"sa-{uuid.uuid4().hex[:8]}", "TestPassword123!", AdminRole.superadmin
+    )
+    set_user(actor)
+    resp = await _client.post(
+        "/admin/users",
+        data={
+            "username": "another-super",
+            "password": "TestPassword123!",
+            "role": "superadmin",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302  # redirect back to /admin/users on success
+
+
+# ── GHSA-24hg: bad username rejected by the create endpoint ────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_xss_username(
+    client: AsyncClient, as_admin, no_csrf
+) -> None:
+    _client, set_user = as_admin
+    set_user(_user(AdminRole.superadmin))
+    resp = await _client.post(
+        "/admin/users",
+        data={
+            "username": "a'+__XSS('x')+'",
+            "password": "TestPassword123!",
+            "role": "admin",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+# ── GHSA-gh23: security headers single-source ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_security_headers_single_and_consistent(client: AsyncClient) -> None:
+    resp = await client.get("/health")
+    # httpx merges duplicate headers with ", "; assert single, unambiguous values.
+    assert resp.headers.get("X-Frame-Options") == "DENY"
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+    hsts = resp.headers.get("Strict-Transport-Security", "")
+    assert hsts.count("max-age=") == 1
+    assert "server" not in {k.lower() for k in resp.headers}

--- a/tests/test_v100.py
+++ b/tests/test_v100.py
@@ -583,7 +583,7 @@ class TestConfigV100Defaults:
     def test_app_version_current(self) -> None:
         from app.config import settings
 
-        assert settings.app_version == "1.1.0"
+        assert settings.app_version == "1.1.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves the four privately-reported security advisories and raises dependency floors.

## Security fixes
- **IDOR / deanonymization** (GHSA-q3v3-5xf4-xjqr) — object-level authorization on every `/admin/reports/{id}*` handler; case managers see only assigned reports, admins only their org.
- **Privilege escalation** (GHSA-g3xj-3929-r45h) — tier checks on role assignment; only superadmins grant/modify superadmin; no self-role-change.
- **Stored XSS** (GHSA-24hg-pf84-jj7x) — username removed from inline `onclick`; moved to `data-confirm` + `site.js`; strict username allowlist.
- **Duplicated headers** (GHSA-gh23-4h5j-cqj8) — nginx no longer re-emits security headers; app middleware is the single source.

## Dependencies
- Raised `>=` floors across all groups to current majors (redis 8, bcrypt 5, mypy 2, pytest 9, …).

## Still to land on this branch
- Full CSP hardening (remove `unsafe-inline` from script-src and style-src).
- Version bump to v1.1.1 + CHANGELOG + docs.

Regression tests added in `tests/test_security_advisories_v111.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)