### PR TITLE
feat(admin): file integrity check on the System page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ migrations/versions/__pycache__/
 
 # Logs
 *.log
+
+# Generated at Docker build time (see scripts/generate_integrity_manifest.py)
+integrity-manifest.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,11 @@ COPY --chown=openwhistle:openwhistle . .
 
 RUN chown -R openwhistle:openwhistle /app/app/static/fonts/
 
+# Generate the file-integrity manifest over the exact shipped bytes (after fonts
+# are in place). -B avoids writing .pyc during the walk (PYTHONDONTWRITEBYTECODE
+# is set later); the script imports no settings, so no SECRET_KEY is needed.
+RUN /venv/bin/python -B scripts/generate_integrity_manifest.py
+
 USER openwhistle
 
 ENV PATH="/venv/bin:$PATH" \

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -1123,13 +1123,16 @@ async def system_page(
     redis: Redis = Depends(get_redis),
     current_user: AdminUser = Depends(require_admin),
 ) -> HTMLResponse:
+    from app.services.integrity import get_integrity_status
     from app.services.version_check import get_update_status
 
     update = await get_update_status(redis, settings.app_version)
+    recheck = request.query_params.get("recheck") == "1"
+    integrity = await get_integrity_status(redis, recheck=recheck)
     return render(
         request,
         "admin/system.html",
-        {"user": current_user, "update": update},
+        {"user": current_user, "update": update, "integrity": integrity},
     )
 
 

--- a/app/locales/de.json
+++ b/app/locales/de.json
@@ -490,5 +490,19 @@
   "admin.system.privacy.body.html": "Wenn aktiviert, führt die Update-Prüfung eine einzelne Anfrage an die öffentliche Releases-API von GitHub aus. Dabei werden <strong>keine</strong> Instanz- oder Meldungsdaten übermittelt — nur eine Standard-HTTP-Anfrage. Das Ergebnis wird zwischengespeichert und einmal täglich aktualisiert.",
   "admin.system.config.title": "Konfiguration",
   "admin.system.config.enabled.desc": "Tägliche GitHub-Update-Prüfung aktivieren (opt-in; es werden keine Daten an GitHub gesendet).",
-  "admin.system.all_releases": "Alle Releases"
+  "admin.system.all_releases": "Alle Releases",
+  "admin.system.integrity.title": "Dateiintegrität",
+  "admin.system.integrity.status": "Integrität",
+  "admin.system.integrity.ok": "Alle Dateien verifiziert",
+  "admin.system.integrity.issues": "Probleme gefunden",
+  "admin.system.integrity.unavailable": "Manifest nicht verfügbar",
+  "admin.system.integrity.checked": "{count} Dateien geprüft",
+  "admin.system.integrity.missing": "Fehlende Dateien",
+  "admin.system.integrity.modified": "Geänderte Dateien",
+  "admin.system.integrity.extra": "Unerwartete Dateien",
+  "admin.system.integrity.generated": "Manifest erstellt",
+  "admin.system.integrity.manifest_hash": "Manifest SHA-256",
+  "admin.system.integrity.recheck": "Jetzt erneut prüfen",
+  "admin.system.integrity.note.html": "Überprüft die Anwendungsdateien anhand eines Manifests, das zur Build-Zeit in dieses Image eingebettet wurde. Dies erkennt versehentliche Änderungen, unvollständige Deployments und Beschädigungen. Es ist <strong>kein</strong> manipulationssicherer Schutz: Ein Angreifer, der Schreibzugriff auf den Container erlangt, könnte auch das Basis-Manifest verändern.",
+  "admin.system.integrity.unavailable_note": "Es ist kein Integritäts-Manifest vorhanden. Das ist außerhalb eines veröffentlichten Docker-Images zu erwarten (z. B. bei lokaler Entwicklung)."
 }

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -490,5 +490,19 @@
   "admin.system.privacy.body.html": "When enabled, the update check performs a single request to GitHub's public releases API. It sends <strong>no</strong> instance or report data — only a standard HTTP request. The result is cached and refreshed once a day.",
   "admin.system.config.title": "Configuration",
   "admin.system.config.enabled.desc": "Enable the daily GitHub update check (opt-in; no data is sent to GitHub).",
-  "admin.system.all_releases": "All releases"
+  "admin.system.all_releases": "All releases",
+  "admin.system.integrity.title": "File integrity",
+  "admin.system.integrity.status": "Integrity",
+  "admin.system.integrity.ok": "All files verified",
+  "admin.system.integrity.issues": "Issues found",
+  "admin.system.integrity.unavailable": "Manifest unavailable",
+  "admin.system.integrity.checked": "{count} files checked",
+  "admin.system.integrity.missing": "Missing files",
+  "admin.system.integrity.modified": "Modified files",
+  "admin.system.integrity.extra": "Unexpected files",
+  "admin.system.integrity.generated": "Manifest generated",
+  "admin.system.integrity.manifest_hash": "Manifest SHA-256",
+  "admin.system.integrity.recheck": "Re-check now",
+  "admin.system.integrity.note.html": "Verifies application files against a manifest baked into this image at build time. This detects accidental modification, incomplete deployments, and corruption. It is <strong>not</strong> tamper-proof: an attacker able to write to the container could also alter the baseline manifest.",
+  "admin.system.integrity.unavailable_note": "No integrity manifest is present. This is expected outside a released Docker image (e.g. local development)."
 }

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -490,5 +490,19 @@
   "admin.system.privacy.body.html": "Lorsqu'elle est activée, la vérification des mises à jour effectue une seule requête vers l'API publique des versions de GitHub. Elle n'envoie <strong>aucune</strong> donnée d'instance ou de signalement — uniquement une requête HTTP standard. Le résultat est mis en cache et actualisé une fois par jour.",
   "admin.system.config.title": "Configuration",
   "admin.system.config.enabled.desc": "Activer la vérification quotidienne des mises à jour sur GitHub (opt-in ; aucune donnée n'est envoyée à GitHub).",
-  "admin.system.all_releases": "Toutes les versions"
+  "admin.system.all_releases": "Toutes les versions",
+  "admin.system.integrity.title": "Intégrité des fichiers",
+  "admin.system.integrity.status": "Intégrité",
+  "admin.system.integrity.ok": "Tous les fichiers vérifiés",
+  "admin.system.integrity.issues": "Problèmes détectés",
+  "admin.system.integrity.unavailable": "Manifeste indisponible",
+  "admin.system.integrity.checked": "{count} fichiers vérifiés",
+  "admin.system.integrity.missing": "Fichiers manquants",
+  "admin.system.integrity.modified": "Fichiers modifiés",
+  "admin.system.integrity.extra": "Fichiers inattendus",
+  "admin.system.integrity.generated": "Manifeste généré",
+  "admin.system.integrity.manifest_hash": "SHA-256 du manifeste",
+  "admin.system.integrity.recheck": "Revérifier maintenant",
+  "admin.system.integrity.note.html": "Vérifie les fichiers de l'application par rapport à un manifeste intégré à cette image lors de sa construction. Cela permet de détecter une modification accidentelle, un déploiement incomplet ou une corruption. Ce n'est <strong>pas</strong> une protection inviolable : un attaquant capable d'écrire dans le conteneur pourrait également altérer le manifeste de référence.",
+  "admin.system.integrity.unavailable_note": "Aucun manifeste d'intégrité n'est présent. C'est normal en dehors d'une image Docker publiée (par ex. en développement local)."
 }

--- a/app/locales/pt-br.json
+++ b/app/locales/pt-br.json
@@ -496,5 +496,19 @@
   "admin.system.privacy.body.html": "Quando ativada, a verificação de atualizações realiza uma única requisição à API pública de versões do GitHub. Ela não envia <strong>nenhum</strong> dado da instância ou de denúncias — apenas uma requisição HTTP padrão. O resultado é armazenado em cache e atualizado uma vez por dia.",
   "admin.system.config.title": "Configuração",
   "admin.system.config.enabled.desc": "Ativar a verificação diária de atualizações no GitHub (opcional; nenhum dado é enviado ao GitHub).",
-  "admin.system.all_releases": "Todas as versões"
+  "admin.system.all_releases": "Todas as versões",
+  "admin.system.integrity.title": "Integridade dos arquivos",
+  "admin.system.integrity.status": "Integridade",
+  "admin.system.integrity.ok": "Todos os arquivos verificados",
+  "admin.system.integrity.issues": "Problemas encontrados",
+  "admin.system.integrity.unavailable": "Manifesto indisponível",
+  "admin.system.integrity.checked": "{count} arquivos verificados",
+  "admin.system.integrity.missing": "Arquivos ausentes",
+  "admin.system.integrity.modified": "Arquivos modificados",
+  "admin.system.integrity.extra": "Arquivos inesperados",
+  "admin.system.integrity.generated": "Manifesto gerado",
+  "admin.system.integrity.manifest_hash": "SHA-256 do manifesto",
+  "admin.system.integrity.recheck": "Verificar novamente agora",
+  "admin.system.integrity.note.html": "Verifica os arquivos da aplicação em relação a um manifesto incorporado a esta imagem no momento da construção. Isso detecta modificações acidentais, implantações incompletas e corrupção. Isso <strong>não</strong> é à prova de violação: um invasor capaz de gravar no contêiner também poderia alterar o manifesto de referência.",
+  "admin.system.integrity.unavailable_note": "Nenhum manifesto de integridade está presente. Isso é esperado fora de uma imagem Docker lançada oficialmente (por exemplo, em desenvolvimento local)."
 }

--- a/app/services/integrity.py
+++ b/app/services/integrity.py
@@ -1,0 +1,195 @@
+"""File integrity check — verify the shipped application files against a manifest.
+
+A SHA-256 manifest of the ``app/`` package is generated at Docker build time
+(``scripts/generate_integrity_manifest.py``) over the exact shipped bytes. At
+runtime we re-hash ``app/`` and diff it against the manifest to surface files
+that are missing, modified, or unexpectedly present.
+
+Scope / honesty: the manifest ships inside the same image (same trust boundary),
+so this reliably detects accidental modification, incomplete/partial deploys and
+corruption — but it is NOT tamper-proof against an attacker who can also rewrite
+the manifest. The manifest's own SHA-256 is surfaced so it can optionally be
+compared against a value published out-of-band (e.g. the signed release).
+
+This module imports no settings and makes no network calls; it only reads local
+files, so it is safe to run always.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path, PurePosixPath
+from typing import Any, TypedDict
+
+from redis.asyncio import Redis
+
+log = logging.getLogger(__name__)
+
+_MANIFEST_NAME = "integrity-manifest.json"
+_CACHE_KEY = "openwhistle:integrity"
+_CACHE_TTL = 300  # 5 minutes
+_CHUNK = 65536
+
+# .../app/services/integrity.py -> APP_ROOT = .../app, REPO_ROOT = ...
+APP_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = APP_ROOT.parent
+DEFAULT_MANIFEST_PATH = REPO_ROOT / _MANIFEST_NAME
+
+
+class ManifestEntry(TypedDict):
+    sha256: str
+    size: int
+
+
+class IntegrityResult(TypedDict):
+    available: bool
+    ok: bool
+    checked: int
+    missing: list[str]
+    modified: list[str]
+    extra: list[str]
+    generated_at: str | None
+    version: str | None
+    manifest_sha256: str | None
+
+
+def _hash_file(path: Path) -> tuple[str, int]:
+    """Streamed SHA-256 + byte size — never loads the whole file into memory."""
+    h = hashlib.sha256()
+    size = 0
+    with path.open("rb") as f:
+        while chunk := f.read(_CHUNK):
+            h.update(chunk)
+            size += len(chunk)
+    return h.hexdigest(), size
+
+
+def build_file_index(root: Path) -> dict[str, ManifestEntry]:
+    """Walk ``root`` and return ``{posix_relpath: {sha256, size}}``.
+
+    Keys are POSIX paths relative to ``root``'s parent (e.g. ``app/main.py``).
+    ``__pycache__`` dirs, ``*.pyc`` files and the manifest file are skipped;
+    symlinked directories are not followed; unreadable files are omitted (they
+    surface as ``missing`` during verification rather than aborting the walk).
+    """
+    base = root.parent
+    index: dict[str, ManifestEntry] = {}
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__"]
+        for filename in filenames:
+            if filename.endswith(".pyc") or filename == _MANIFEST_NAME:
+                continue
+            file_path = Path(dirpath) / filename
+            key = PurePosixPath(file_path.relative_to(base).as_posix()).as_posix()
+            try:
+                digest, size = _hash_file(file_path)
+            except OSError:
+                log.warning("Integrity: could not read %s", key)
+                continue
+            index[key] = {"sha256": digest, "size": size}
+    return index
+
+
+def load_manifest(manifest_path: Path) -> dict[str, Any] | None:
+    """Load the manifest, or None if absent / malformed / empty."""
+    try:
+        raw = manifest_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict) or not parsed.get("files"):
+        return None
+    return parsed
+
+
+def _manifest_sha256(manifest_path: Path) -> str | None:
+    try:
+        return _hash_file(manifest_path)[0]
+    except OSError:
+        return None
+
+
+def _unavailable() -> IntegrityResult:
+    return {
+        "available": False,
+        "ok": False,
+        "checked": 0,
+        "missing": [],
+        "modified": [],
+        "extra": [],
+        "generated_at": None,
+        "version": None,
+        "manifest_sha256": None,
+    }
+
+
+def verify_integrity(
+    root: Path = APP_ROOT, manifest_path: Path = DEFAULT_MANIFEST_PATH
+) -> IntegrityResult:
+    """Diff the on-disk ``app/`` tree against the baked manifest (synchronous)."""
+    manifest = load_manifest(manifest_path)
+    if manifest is None:
+        return _unavailable()
+
+    files: dict[str, Any] = manifest.get("files", {})
+    current = build_file_index(root)
+
+    missing: list[str] = []
+    modified: list[str] = []
+    for path, entry in files.items():
+        cur = current.get(path)
+        if cur is None:
+            missing.append(path)
+        elif cur["sha256"] != entry.get("sha256") or cur["size"] != entry.get("size"):
+            modified.append(path)
+    extra = sorted(set(current) - set(files))
+    missing.sort()
+    modified.sort()
+
+    return {
+        "available": True,
+        "ok": not (missing or modified or extra),
+        "checked": len(current),
+        "missing": missing,
+        "modified": modified,
+        "extra": extra,
+        "generated_at": manifest.get("generated_at"),
+        "version": manifest.get("version"),
+        "manifest_sha256": _manifest_sha256(manifest_path),
+    }
+
+
+async def get_integrity_status(redis: Redis, recheck: bool = False) -> dict[str, Any]:
+    """Cached integrity status for the admin page.
+
+    Runs the (fast, local) verification in a thread so the event loop is never
+    blocked, and caches the result in Redis. ``recheck`` busts the cache.
+    """
+    if recheck:
+        try:
+            await redis.delete(_CACHE_KEY)
+        except Exception:  # noqa: BLE001, S110
+            pass
+    else:
+        raw = await redis.get(_CACHE_KEY)
+        if raw:
+            try:
+                cached = json.loads(raw)
+            except (ValueError, TypeError):
+                cached = None
+            if isinstance(cached, dict):
+                return cached
+
+    result = await asyncio.to_thread(verify_integrity)
+    try:
+        await redis.setex(_CACHE_KEY, _CACHE_TTL, json.dumps(result))
+    except Exception:  # noqa: BLE001, S110
+        pass
+    return dict(result)

--- a/app/templates/admin/system.html
+++ b/app/templates/admin/system.html
@@ -79,6 +79,56 @@
     </p>
     {% endif %}
 
+    <section class="card" aria-labelledby="heading-integrity">
+        <h2 id="heading-integrity">{{ t('admin.system.integrity.title') }}</h2>
+
+        <div class="detail-row">
+            <div class="detail-label">{{ t('admin.system.integrity.status') }}</div>
+            {% if not integrity.available %}
+                <span class="badge badge--grey">{{ t('admin.system.integrity.unavailable') }}</span>
+            {% elif integrity.ok %}
+                <span class="badge badge--green">&#10003; {{ t('admin.system.integrity.ok') }}</span>
+            {% else %}
+                <span class="badge badge--amber">{{ t('admin.system.integrity.issues') }}</span>
+            {% endif %}
+        </div>
+
+        {% if not integrity.available %}
+        <p class="note">{{ t('admin.system.integrity.unavailable_note') }}</p>
+        {% else %}
+        <p class="note">
+            {{ t('admin.system.integrity.checked', count=integrity.checked) }}
+            {% if integrity.generated_at %}
+                &middot; {{ t('admin.system.integrity.generated') }}
+                <time data-utc="{{ integrity.generated_at }}">{{ integrity.generated_at }}</time>
+            {% endif %}
+        </p>
+
+        {% if integrity.missing %}
+        <h3>{{ t('admin.system.integrity.missing') }}</h3>
+        <ul class="mono">{% for f in integrity.missing %}<li>{{ f }}</li>{% endfor %}</ul>
+        {% endif %}
+        {% if integrity.modified %}
+        <h3>{{ t('admin.system.integrity.modified') }}</h3>
+        <ul class="mono">{% for f in integrity.modified %}<li>{{ f }}</li>{% endfor %}</ul>
+        {% endif %}
+        {% if integrity.extra %}
+        <h3>{{ t('admin.system.integrity.extra') }}</h3>
+        <ul class="mono">{% for f in integrity.extra %}<li>{{ f }}</li>{% endfor %}</ul>
+        {% endif %}
+
+        {% if integrity.manifest_sha256 %}
+        <p class="note">
+            {{ t('admin.system.integrity.manifest_hash') }}
+            <code>{{ integrity.manifest_sha256 }}</code>
+        </p>
+        {% endif %}
+        {% endif %}
+
+        <p class="note">{{ t('admin.system.integrity.note.html') }}</p>
+        <p><a href="?recheck=1">{{ t('admin.system.integrity.recheck') }}</a></p>
+    </section>
+
     <section class="card" aria-labelledby="heading-privacy">
         <h2 id="heading-privacy">{{ t('admin.system.privacy.title') }}</h2>
         <p>{{ t('admin.system.privacy.body.html') }}</p>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1634,6 +1634,13 @@
           available on GitHub (checked once a day, cached; no instance data is sent). The check
           is opt-in and off by default.
         </p>
+        <p>
+          The same page includes a <strong>file integrity check</strong>: it verifies the
+          application files against a SHA-256 manifest baked into the image at build time and
+          reports any missing, modified, or unexpected files. This detects accidental
+          modification, incomplete deployments, and corruption; it is not tamper-proof against an
+          attacker who can also rewrite the manifest. Use the "Re-check now" link to refresh.
+        </p>
 
         <h3>HinSchG deadline tracking</h3>
         <p>

--- a/scripts/generate_integrity_manifest.py
+++ b/scripts/generate_integrity_manifest.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Generate the file-integrity manifest for the ``app/`` package.
+
+Run at Docker build time over the exact shipped bytes:
+
+    python -B scripts/generate_integrity_manifest.py
+
+Thin wrapper around ``app.services.integrity.build_file_index`` so the build and
+the runtime verifier share one walk/hash implementation (they must never
+diverge). Writes ``integrity-manifest.json`` at the repo/image root.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Ensure the repo root is importable when invoked as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services.integrity import (  # noqa: E402
+    APP_ROOT,
+    DEFAULT_MANIFEST_PATH,
+    build_file_index,
+)
+
+
+def _app_version() -> str:
+    """Read app_version from the config source.
+
+    Parsed from text rather than imported: importing app.config would run the
+    module-level ``settings = Settings()``, which requires SECRET_KEY (>=32) —
+    not available during a plain image build.
+    """
+    import re
+
+    try:
+        source = (APP_ROOT / "config.py").read_text(encoding="utf-8")
+    except OSError:
+        return "unknown"
+    match = re.search(r'app_version:\s*str\s*=\s*"([^"]+)"', source)
+    return match.group(1) if match else "unknown"
+
+
+def main() -> None:
+    index = build_file_index(APP_ROOT)
+    manifest = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "version": _app_version(),
+        "algorithm": "sha256",
+        "files": index,
+    }
+    DEFAULT_MANIFEST_PATH.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    print(f"Wrote {DEFAULT_MANIFEST_PATH} ({len(index)} files)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,150 @@
+"""Tests for the file-integrity service and its admin System-page section."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+
+from app.api.deps import get_current_admin
+from app.main import app
+from app.models.user import AdminRole, AdminUser
+from app.services import integrity as ig
+
+
+def _make_tree(tmp_path: Path) -> Path:
+    """Build a small app-like tree with noise (pycache/pyc) that must be skipped."""
+    appdir = tmp_path / "app"
+    (appdir / "sub").mkdir(parents=True)
+    (appdir / "a.py").write_text("print('a')", encoding="utf-8")
+    (appdir / "sub" / "b.txt").write_text("hello", encoding="utf-8")
+    (appdir / "empty.txt").write_text("", encoding="utf-8")
+    (appdir / "__pycache__").mkdir()
+    (appdir / "__pycache__" / "x.cpython-314.pyc").write_text("junk", encoding="utf-8")
+    (appdir / "c.pyc").write_text("junk", encoding="utf-8")
+    return appdir
+
+
+def _write_manifest(path: Path, appdir: Path) -> None:
+    idx = ig.build_file_index(appdir)
+    path.write_text(
+        json.dumps({"generated_at": "t", "version": "9.9.9", "algorithm": "sha256", "files": idx}),
+        encoding="utf-8",
+    )
+
+
+def test_build_file_index_keys_and_skips(tmp_path: Path) -> None:
+    appdir = _make_tree(tmp_path)
+    idx = ig.build_file_index(appdir)
+    # __pycache__ and *.pyc excluded; POSIX keys relative to the app parent.
+    assert set(idx) == {"app/a.py", "app/sub/b.txt", "app/empty.txt"}
+    assert idx["app/a.py"]["size"] == len("print('a')")
+    assert idx["app/empty.txt"]["size"] == 0
+    assert len(idx["app/a.py"]["sha256"]) == 64
+
+
+def test_verify_ok_round_trip(tmp_path: Path) -> None:
+    appdir = _make_tree(tmp_path)
+    manifest = tmp_path / "m.json"
+    _write_manifest(manifest, appdir)
+    r = ig.verify_integrity(root=appdir, manifest_path=manifest)
+    assert r["available"] is True
+    assert r["ok"] is True
+    assert r["checked"] == 3
+    assert r["version"] == "9.9.9"
+    assert r["manifest_sha256"] and len(r["manifest_sha256"]) == 64
+    assert not r["missing"] and not r["modified"] and not r["extra"]
+
+
+def test_verify_detects_missing_modified_extra(tmp_path: Path) -> None:
+    appdir = _make_tree(tmp_path)
+    manifest = tmp_path / "m.json"
+    _write_manifest(manifest, appdir)
+    m = json.loads(manifest.read_text())
+    m["files"]["app/GONE.py"] = {"sha256": "0" * 64, "size": 1}  # missing on disk
+    m["files"]["app/a.py"]["sha256"] = "deadbeef"                # hash mismatch → modified
+    del m["files"]["app/sub/b.txt"]                              # on disk, not in manifest → extra
+    manifest.write_text(json.dumps(m), encoding="utf-8")
+
+    r = ig.verify_integrity(root=appdir, manifest_path=manifest)
+    assert r["ok"] is False
+    assert "app/GONE.py" in r["missing"]
+    assert "app/a.py" in r["modified"]
+    assert "app/sub/b.txt" in r["extra"]
+
+
+def test_verify_detects_size_only_change(tmp_path: Path) -> None:
+    appdir = _make_tree(tmp_path)
+    manifest = tmp_path / "m.json"
+    _write_manifest(manifest, appdir)
+    m = json.loads(manifest.read_text())
+    m["files"]["app/a.py"]["size"] = 99999  # size mismatch alone → modified
+    manifest.write_text(json.dumps(m), encoding="utf-8")
+    r = ig.verify_integrity(root=appdir, manifest_path=manifest)
+    assert "app/a.py" in r["modified"]
+
+
+@pytest.mark.parametrize(
+    "content",
+    [None, "{ not json", json.dumps({"files": {}}), json.dumps({"other": 1}), json.dumps([1, 2])],
+)
+def test_verify_unavailable(tmp_path: Path, content: str | None) -> None:
+    appdir = _make_tree(tmp_path)
+    manifest = tmp_path / "m.json"
+    if content is not None:
+        manifest.write_text(content, encoding="utf-8")
+    r = ig.verify_integrity(root=appdir, manifest_path=manifest)
+    assert r["available"] is False
+    assert r["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_integrity_status_caches_result() -> None:
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.setex = AsyncMock()
+    result = await ig.get_integrity_status(redis)
+    assert "available" in result
+    redis.setex.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_integrity_status_recheck_busts_cache() -> None:
+    redis = AsyncMock()
+    redis.delete = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    redis.setex = AsyncMock()
+    await ig.get_integrity_status(redis, recheck=True)
+    redis.delete.assert_awaited_once()
+    redis.get.assert_not_called()  # recheck skips the cache read
+
+
+# ── Integration: admin System page renders the integrity section ───────────
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def as_admin(client: AsyncClient):
+    admin = AdminUser(
+        id=uuid.uuid4(),
+        username="sysadmin2",
+        role=AdminRole.admin,
+        is_active=True,
+        totp_secret="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        totp_enabled=True,
+    )
+    app.dependency_overrides[get_current_admin] = lambda: admin
+    yield client
+    app.dependency_overrides.pop(get_current_admin, None)
+
+
+@pytest.mark.asyncio
+async def test_system_page_renders_integrity_section(as_admin: AsyncClient) -> None:
+    # No manifest ships in the test env → the section renders as "unavailable".
+    resp = await as_admin.get("/admin/system", follow_redirects=False)
+    assert resp.status_code == 200
+    assert "integrity" in resp.text.lower()


### PR DESCRIPTION
Adds a **file integrity check** to the Admin → System page: verifies the shipped `app/` files against a SHA-256 manifest baked into the image at build time, and reports any **missing / modified / unexpected** files.

## Design
- **One shared `build_file_index`** (`app/services/integrity.py`) used by both the build-time generator and the runtime verifier → they can't drift. Streamed SHA-256, POSIX keys, skips `__pycache__`/`*.pyc`, `OSError`-safe, doesn't follow symlinked dirs.
- Manifest generated at build (`scripts/generate_integrity_manifest.py`, run via `python -B` in the Dockerfile after the fonts step) → `/app/integrity-manifest.json` (sibling of `app/`, gitignored). No `SECRET_KEY` needed at build (version read from source).
- Runtime `get_integrity_status` caches in Redis + runs off the event loop (`asyncio.to_thread`); `?recheck=1` busts the cache. No new env var; "unavailable" when no manifest (local dev).
- **Honest scope**: detects accidental modification / partial deploys / corruption — not a determined attacker who also rewrites the manifest (stated in the UI); the manifest's own SHA-256 is shown for optional out-of-band verification.

Logic validated locally (round-trip OK; missing/modified/extra/unavailable all detected). Full suite + Docker build in CI. i18n across 4 locales, docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)