### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0] — 2026-07-13
+
 ### Added
 
 - **Admin System page + opt-in update check**: a new **Admin → System** page
@@ -15,6 +17,12 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a daily background job (result cached in Redis, ETag-conditional), and sends no
   instance data to GitHub — only a standard request. The installed version is
   also shown in the footer.
+- **File integrity check** on the Admin → System page: verifies the shipped
+  application files against a SHA-256 manifest generated at Docker build time and
+  reports any missing, modified, or unexpected files. Purely local (no external
+  calls); detects accidental modification, incomplete deployments and corruption
+  (not tamper-proof against an attacker who can also rewrite the manifest — the
+  manifest's own hash is shown for optional out-of-band verification).
 
 ## [1.1.1] — 2026-07-13
 

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "OpenWhistle"
-    app_version: str = "1.1.1"
+    app_version: str = "1.2.0"
 
     # Logging
     log_level: str = "INFO"

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -821,7 +821,7 @@
 
         <h3>Current version</h3>
         <p>
-          <strong>v1.1.1</strong> — Security release: object-level report authorization (deanonymization / IDOR fix), privilege-escalation guards on role assignment, stored-XSS hardening, and a strict nonce-based Content-Security-Policy with consolidated security headers. See the
+          <strong>v1.2.0</strong> — Admin System page: installed-version display, opt-in daily GitHub update check, and a build-time file-integrity check. Builds on the v1.1.1 security release (report authorization, privilege-escalation guards, stored-XSS hardening, strict nonce-based CSP). See the
           <a href="https://github.com/openwhistle/OpenWhistle/blob/main/CHANGELOG.md" rel="noopener noreferrer" target="_blank">CHANGELOG</a>
           for a full list of changes.
         </p>

--- a/tests/test_v100.py
+++ b/tests/test_v100.py
@@ -583,7 +583,7 @@ class TestConfigV100Defaults:
     def test_app_version_current(self) -> None:
         from app.config import settings
 
-        assert settings.app_version == "1.1.1"
+        assert settings.app_version == "1.2.0"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Release **v1.2.0** — bundles the two admin System-page features:

- Installed-version display + opt-in daily GitHub update check.
- Build-time file-integrity check (missing/modified/extra).

Bumps `app_version` to 1.2.0, finalizes the CHANGELOG `[1.2.0]` entry, updates the docs current-version.

After merge: tag `v1.2.0` and publish the GitHub Release (triggers the multi-registry Docker push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)