### PR TITLE
fix(storage): 404 on missing S3 object (#45)

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -579,8 +579,14 @@ async def admin_download_attachment(
         raise HTTPException(status_code=404)
 
     if attachment.storage_key:
-        from app.services.storage import get_storage_backend
-        data = await get_storage_backend().get(attachment.storage_key)
+        from app.services.storage import (
+            StorageObjectNotFoundError,
+            get_storage_backend,
+        )
+        try:
+            data = await get_storage_backend().get(attachment.storage_key)
+        except StorageObjectNotFoundError as exc:
+            raise HTTPException(status_code=404) from exc
     else:
         if attachment.data is None:
             raise HTTPException(status_code=404)

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -744,8 +744,14 @@ async def whistleblower_download_attachment(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
 
     if attachment.storage_key:
-        from app.services.storage import get_storage_backend
-        data = await get_storage_backend().get(attachment.storage_key)
+        from app.services.storage import (
+            StorageObjectNotFoundError,
+            get_storage_backend,
+        )
+        try:
+            data = await get_storage_backend().get(attachment.storage_key)
+        except StorageObjectNotFoundError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND) from exc
     else:
         if attachment.data is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -17,6 +17,14 @@ from typing import Any
 log = logging.getLogger(__name__)
 
 
+class StorageObjectNotFoundError(Exception):
+    """Raised when an attachment's stored object is missing from the backend.
+
+    Lets the download handlers return a clean 404 instead of surfacing a raw
+    backend error as a 500 (e.g. the S3 object was deleted out-of-band).
+    """
+
+
 class StorageBackend:
     """Thin protocol that both backends implement."""
 
@@ -90,11 +98,19 @@ class S3StorageBackend(StorageBackend):
         log.info("Stored attachment in S3: %s", full_key)
 
     async def get(self, key: str) -> bytes:
+        from botocore.exceptions import ClientError  # noqa: PLC0415
+
         client = self._client()
         full_key = self._full_key(key)
-        response = await asyncio.to_thread(
-            client.get_object, Bucket=self._bucket, Key=full_key
-        )
+        try:
+            response = await asyncio.to_thread(
+                client.get_object, Bucket=self._bucket, Key=full_key
+            )
+        except ClientError as exc:
+            code = str(exc.response.get("Error", {}).get("Code", ""))
+            if code in {"NoSuchKey", "NoSuchBucket", "404", "AccessDenied"}:
+                raise StorageObjectNotFoundError(full_key) from exc
+            raise  # a genuine backend/connectivity error stays a 5xx
         body: bytes = await asyncio.to_thread(response["Body"].read)
         return body
 

--- a/tests/test_issue_45_s3_missing.py
+++ b/tests/test_issue_45_s3_missing.py
@@ -1,0 +1,91 @@
+"""Issue #45 — a missing S3 object must yield 404, not an unhandled 500."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from botocore.exceptions import ClientError
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_admin
+from app.main import app
+from app.models.user import AdminRole, AdminUser
+from app.services.storage import S3StorageBackend, StorageObjectNotFoundError
+
+
+def _s3_backend() -> S3StorageBackend:
+    return S3StorageBackend(
+        bucket="b", prefix="p/", region="r", access_key="k", secret_key="s", endpoint_url=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_s3_get_missing_object_raises_not_found() -> None:
+    client = MagicMock()
+    client.get_object.side_effect = ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+    with patch("boto3.client", return_value=client), pytest.raises(StorageObjectNotFoundError):
+        await _s3_backend().get("some/key")
+
+
+@pytest.mark.asyncio
+async def test_s3_get_other_error_propagates() -> None:
+    """A genuine backend error must NOT be masked as not-found (stays a 5xx)."""
+    client = MagicMock()
+    client.get_object.side_effect = ClientError({"Error": {"Code": "InternalError"}}, "GetObject")
+    with patch("boto3.client", return_value=client), pytest.raises(ClientError):
+        await _s3_backend().get("some/key")
+
+
+# ── Handler maps the missing-object error to 404 ───────────────────────────
+
+
+class _RaisingBackend:
+    async def get(self, key: str) -> bytes:
+        raise StorageObjectNotFoundError(key)
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def as_admin(client: AsyncClient):
+    admin = AdminUser(
+        id=uuid.uuid4(),
+        username="dl-admin",
+        role=AdminRole.admin,
+        is_active=True,
+        totp_secret="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        totp_enabled=True,
+    )
+    app.dependency_overrides[get_current_admin] = lambda: admin
+    yield client
+    app.dependency_overrides.pop(get_current_admin, None)
+
+
+@pytest.mark.asyncio
+async def test_admin_download_missing_s3_object_returns_404(
+    db_session: AsyncSession, as_admin: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.models.attachment import Attachment
+    from app.services import storage
+    from app.services.report import create_report
+
+    report, _ = await create_report(db_session, "financial_fraud", "S3 missing object test.")
+    att = Attachment(
+        id=uuid.uuid4(),
+        report_id=report.id,
+        filename="evidence.pdf",
+        content_type="application/pdf",
+        size=3,
+        data=None,
+        storage_key="k/evidence.pdf",
+    )
+    db_session.add(att)
+    await db_session.commit()
+
+    monkeypatch.setattr(storage, "get_storage_backend", lambda: _RaisingBackend())
+    resp = await as_admin.get(
+        f"/admin/reports/{report.id}/attachments/{att.id}", follow_redirects=False
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
Closes #45. `S3StorageBackend.get` raised a raw botocore `ClientError` for a missing object → unhandled 500. Now maps NoSuchKey/NoSuchBucket/404/AccessDenied to a typed `StorageObjectNotFoundError`, which both download handlers turn into a 404; genuine backend errors still surface as 5xx. Unit + handler tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)