### PR TITLE
fix(csrf): protect ip-warning/dismiss + demo/reset (#44)

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_current_admin, require_admin, require_superadmin
 from app.config import settings
-from app.csrf import validate_csrf
+from app.csrf import validate_csrf, validate_csrf_header
 from app.database import get_db
 from app.middleware import check_ip_warning, clear_ip_warning
 from app.models.report import STATUS_TRANSITIONS, Report, ReportStatus
@@ -1069,7 +1069,7 @@ async def reactivate_location(
 @router.post("/ip-warning/dismiss")
 async def dismiss_ip_warning(
     current_user: AdminUser = Depends(get_current_admin),
-    _csrf: None = Depends(validate_csrf),
+    _csrf: None = Depends(validate_csrf_header),
 ) -> JSONResponse:
     await clear_ip_warning()
     return JSONResponse({"cleared": True})
@@ -1078,7 +1078,7 @@ async def dismiss_ip_warning(
 @router.post("/demo/reset")
 async def demo_reset(
     current_user: AdminUser = Depends(get_current_admin),
-    _csrf: None = Depends(validate_csrf),
+    _csrf: None = Depends(validate_csrf_header),
 ) -> JSONResponse:
     if not settings.demo_mode:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -1069,6 +1069,7 @@ async def reactivate_location(
 @router.post("/ip-warning/dismiss")
 async def dismiss_ip_warning(
     current_user: AdminUser = Depends(get_current_admin),
+    _csrf: None = Depends(validate_csrf),
 ) -> JSONResponse:
     await clear_ip_warning()
     return JSONResponse({"cleared": True})
@@ -1077,6 +1078,7 @@ async def dismiss_ip_warning(
 @router.post("/demo/reset")
 async def demo_reset(
     current_user: AdminUser = Depends(get_current_admin),
+    _csrf: None = Depends(validate_csrf),
 ) -> JSONResponse:
     if not settings.demo_mode:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)

--- a/app/csrf.py
+++ b/app/csrf.py
@@ -2,7 +2,7 @@
 
 import secrets
 
-from fastapi import Cookie, Form, HTTPException, status
+from fastapi import Cookie, Form, Header, HTTPException, status
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -57,11 +57,18 @@ def _parse_cookie(header: str, name: str) -> str | None:
 
 
 async def validate_csrf(
-    csrf_token: str = Form(...),
+    csrf_token: str | None = Form(None),
+    x_csrf_token: str | None = Header(None),
     ow_csrf: str | None = Cookie(None),
 ) -> None:
-    """Dependency: validates CSRF double-submit token on state-changing form submissions."""
-    if not ow_csrf or not secrets.compare_digest(csrf_token, ow_csrf):
+    """Validate the CSRF double-submit token on state-changing requests.
+
+    The submitted token may arrive either as a ``csrf_token`` form field (HTML
+    form posts) or an ``X-CSRF-Token`` header (fetch/AJAX, which cannot read the
+    HttpOnly cookie and instead reads the token from the page's meta tag).
+    """
+    submitted = csrf_token or x_csrf_token
+    if not ow_csrf or not submitted or not secrets.compare_digest(submitted, ow_csrf):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="CSRF validation failed.",

--- a/app/csrf.py
+++ b/app/csrf.py
@@ -57,18 +57,28 @@ def _parse_cookie(header: str, name: str) -> str | None:
 
 
 async def validate_csrf(
-    csrf_token: str | None = Form(None),
+    csrf_token: str = Form(...),
+    ow_csrf: str | None = Cookie(None),
+) -> None:
+    """Dependency: validates CSRF double-submit token on state-changing form submissions."""
+    if not ow_csrf or not secrets.compare_digest(csrf_token, ow_csrf):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF validation failed.",
+        )
+
+
+async def validate_csrf_header(
     x_csrf_token: str | None = Header(None),
     ow_csrf: str | None = Cookie(None),
 ) -> None:
-    """Validate the CSRF double-submit token on state-changing requests.
+    """CSRF validation for fetch/AJAX endpoints (no form body).
 
-    The submitted token may arrive either as a ``csrf_token`` form field (HTML
-    form posts) or an ``X-CSRF-Token`` header (fetch/AJAX, which cannot read the
-    HttpOnly cookie and instead reads the token from the page's meta tag).
+    The token arrives in the ``X-CSRF-Token`` header — JavaScript reads it from
+    the ``<meta name="csrf-token">`` tag since the double-submit cookie is
+    HttpOnly. Same double-submit comparison against the ``ow_csrf`` cookie.
     """
-    submitted = csrf_token or x_csrf_token
-    if not ow_csrf or not submitted or not secrets.compare_digest(submitted, ow_csrf):
+    if not ow_csrf or not x_csrf_token or not secrets.compare_digest(x_csrf_token, ow_csrf):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="CSRF validation failed.",

--- a/app/static/js/site.js
+++ b/app/static/js/site.js
@@ -68,11 +68,21 @@ window.copyToClipboard = async function (text, btn) {
     }
 };
 
+// ─── CSRF token (from the meta tag) for fetch/AJAX requests ─────────────────
+
+function csrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') || '' : '';
+}
+
 // ─── IP warning dismiss ────────────────────────────────────────────────────
 
 window.dismissIpWarning = async function (btn) {
     try {
-        const res = await fetch('/admin/ip-warning/dismiss', { method: 'POST' });
+        const res = await fetch('/admin/ip-warning/dismiss', {
+            method: 'POST',
+            headers: { 'X-CSRF-Token': csrfToken() },
+        });
         if (res.ok) {
             const banner = document.getElementById('ip-warning-banner');
             if (banner) {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <meta name="referrer" content="no-referrer">
+    <meta name="csrf-token" content="{{ request.state.csrf_token }}">
     <title>{% block title %}{{ brand.name }}{% endblock %}</title>
 
     {# No external resources - DSGVO compliance #}

--- a/tests/test_coverage_admin_extended.py
+++ b/tests/test_coverage_admin_extended.py
@@ -369,10 +369,25 @@ async def test_dismiss_ip_warning_returns_cleared(
     admin, totp_secret = await _create_admin(db_session)
     await _login_admin(client, admin, totp_secret)
 
-    resp = await client.post("/admin/ip-warning/dismiss")
+    # AJAX endpoint requires the CSRF token via the X-CSRF-Token header
+    # (double-submit: header must equal the ow_csrf cookie).
+    token = client.cookies.get("ow_csrf")
+    resp = await client.post(
+        "/admin/ip-warning/dismiss", headers={"X-CSRF-Token": token or ""}
+    )
     assert resp.status_code == 200
-    data = resp.json()
-    assert data.get("cleared") is True
+    assert resp.json().get("cleared") is True
+
+
+@pytest.mark.asyncio
+async def test_dismiss_ip_warning_rejects_missing_csrf(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    admin, totp_secret = await _create_admin(db_session)
+    await _login_admin(client, admin, totp_secret)
+
+    resp = await client.post("/admin/ip-warning/dismiss")  # no CSRF token
+    assert resp.status_code == 403
 
 
 # ─── delete_report (cleanup_report_sessions) ─────────────────────────────────


### PR DESCRIPTION
Closes #44. Both admin POST endpoints now require CSRF. `validate_csrf` additionally accepts an `X-CSRF-Token` header (the dismiss endpoint is a fetch and can't read the HttpOnly double-submit cookie), with the token exposed via a `<meta name="csrf-token">` tag and sent by `site.js`. Form posts are unchanged. Tests: dismiss with header → 200, without → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)