### PR TITLE
fix(security): nginx flood protection + drop dead SSO branch (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- Reverse-proxy flood protection for the submission channel: the bundled nginx
+  configs now apply a per-IP `limit_req` to dynamic endpoints. The IP is used
+  only for in-memory throttling — never logged or forwarded upstream — so
+  whistleblower anonymity is preserved (#46).
+- Removed a dead, unreachable "this account uses Single Sign-On" login branch;
+  SSO-only accounts already receive the generic "invalid credentials" error,
+  which avoids leaking account existence / auth method (#46).
+
 ## [1.2.0] — 2026-07-13
 
 ### Added

--- a/ansible/roles/openwhistle/templates/nginx.conf.j2
+++ b/ansible/roles/openwhistle/templates/nginx.conf.j2
@@ -15,6 +15,13 @@ http {
     log_not_found off;
     server_tokens off;
 
+    # Flood protection for dynamic endpoints (submission channel especially).
+    # Keys on the client IP only for in-memory throttling — the IP is NOT logged
+    # or forwarded upstream (access_log is off; IP headers are stripped below),
+    # so whistleblower anonymity is preserved while abusive bursts are limited.
+    limit_req_zone $binary_remote_addr zone=ow_req:10m rate=10r/s;
+    limit_req_status 429;
+
     upstream openwhistle {
         server app:4009;
         keepalive 32;
@@ -61,6 +68,9 @@ http {
         proxy_set_header Connection "";
 
         location / {
+            # Generous burst so the multi-step submission wizard and normal
+            # admin use are unaffected; blocks rapid automated floods.
+            limit_req zone=ow_req burst=30 nodelay;
             proxy_pass http://openwhistle;
             proxy_read_timeout 60s;
             proxy_connect_timeout 10s;
@@ -93,6 +103,9 @@ http {
         proxy_set_header Connection "";
 
         location / {
+            # Generous burst so the multi-step submission wizard and normal
+            # admin use are unaffected; blocks rapid automated floods.
+            limit_req zone=ow_req burst=30 nodelay;
             proxy_pass http://openwhistle;
             proxy_read_timeout 60s;
             proxy_connect_timeout 10s;

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -135,11 +135,10 @@ async def login_post(
         }), status_code=401)
 
     assert user is not None  # narrowed: pw_ok True implies user is not None
-    # Block password login for OIDC-only accounts
-    if user.oidc_sub and not user.password_hash:
-        return render(request, "login.html", _login_ctx({
-            "error": "This account uses Single Sign-On. Please use the SSO button.",
-        }))
+    # Note: SSO-only accounts (oidc_sub set, no password_hash) never reach here —
+    # pw_ok is False for them, so they already received the generic 401 above.
+    # We intentionally do NOT reveal "this account uses SSO", which would leak
+    # account existence / auth method (kept generic for privacy).
 
     if not user.totp_enabled:
         setup_token = secrets.token_urlsafe(32)

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,6 +19,13 @@ http {
     # Server tokens (hide nginx version)
     server_tokens off;
 
+    # ─── Flood protection ────────────────────────────────────────────────
+    # Keys on the client IP for in-memory rate limiting only — the IP is never
+    # logged (access_log off) or forwarded upstream (stripped below), so
+    # anonymity is preserved while abusive request bursts are throttled.
+    limit_req_zone $binary_remote_addr zone=ow_req:10m rate=10r/s;
+    limit_req_status 429;
+
     # ─── Upstream: OpenWhistle application ───────────────────────────────
     upstream openwhistle {
         server app:4009;
@@ -48,6 +55,9 @@ http {
         proxy_set_header Connection "";
 
         location / {
+            # Generous burst so the multi-step submission wizard and normal
+            # admin use are unaffected; blocks rapid automated floods.
+            limit_req zone=ow_req burst=30 nodelay;
             proxy_pass http://openwhistle;
             proxy_read_timeout 60s;
             proxy_connect_timeout 10s;

--- a/tests/test_issue_46.py
+++ b/tests/test_issue_46.py
@@ -1,0 +1,44 @@
+"""Issue #46 — SSO-only accounts get a generic login error (no account-type leak)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import AdminUser
+
+
+@pytest.mark.asyncio
+async def test_sso_only_account_password_login_returns_generic_error(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # An OIDC-only account: oidc_sub set, no local password hash.
+    user = AdminUser(
+        id=uuid.uuid4(),
+        username="ssouser",
+        password_hash=None,
+        oidc_sub="sub-123",
+        oidc_issuer="https://idp.example",
+        totp_secret="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        totp_enabled=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+    get_resp = await client.get("/admin/login")
+    m = re.search(r'name="csrf_token" value="([^"]+)"', get_resp.text)
+    csrf = m.group(1) if m else (get_resp.cookies.get("ow_csrf") or "")
+
+    resp = await client.post(
+        "/admin/login",
+        data={"username": "ssouser", "password": "anything", "csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 401
+    # Must not reveal the account exists / uses SSO — keep the error generic.
+    assert "Single Sign-On" not in resp.text
+    assert "Invalid username or password" in resp.text


### PR DESCRIPTION
Closes #46.

- **Flood protection at the proxy**: bundled nginx configs get a per-IP `limit_req` (10r/s, burst 30 nodelay) on dynamic endpoints. This is the effective place to throttle anonymous submissions — an app-level IP-less limit is bypassable by rotating the session cookie, and the app forbids IP logging. The IP keys nginx's in-memory zone only; it is never logged (`access_log off`) or forwarded upstream (stripped), so anonymity holds.
- **Dead SSO branch removed**: the `if user.oidc_sub and not user.password_hash` check was unreachable; SSO-only accounts already get the generic invalid-credentials error (no account-existence/auth-method leak). Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)