### PR TITLE
fix(security): magic-byte attachment verification (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- Attachment uploads are now verified by magic number: the file's leading bytes
+  must match its extension (PDF, JPEG, PNG, GIF, WebP, DOCX/XLSX, DOC/XLS), so a
+  file cannot lie about its type (e.g. HTML bytes disguised as a `.png`). Text
+  formats have no signature and are unaffected (#43).
 - Reverse-proxy flood protection for the submission channel: the bundled nginx
   configs now apply a per-IP `limit_req` to dynamic endpoints. The IP is used
   only for in-memory throttling — never logged or forwarded upstream — so

--- a/app/services/attachment.py
+++ b/app/services/attachment.py
@@ -70,8 +70,43 @@ def content_disposition_attachment(filename: str) -> str:
     return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{utf8_name}"
 
 
-def validate_file(filename: str, content_type: str, size: int) -> str | None:
-    """Return an error string if the file is invalid, or None if it's acceptable."""
+# Expected leading bytes (magic numbers) per extension, so the declared type /
+# extension cannot lie about the actual content (e.g. HTML bytes named .png).
+# Text formats (.txt/.csv) have no signature and are intentionally omitted.
+_MAGIC_BY_EXT: dict[str, tuple[bytes, ...]] = {
+    ".pdf": (b"%PDF",),
+    ".jpg": (b"\xff\xd8\xff",),
+    ".jpeg": (b"\xff\xd8\xff",),
+    ".png": (b"\x89PNG\r\n\x1a\n",),
+    ".gif": (b"GIF87a", b"GIF89a"),
+    ".webp": (b"RIFF",),  # RIFF container; the WEBP marker is checked separately
+    ".docx": (b"PK\x03\x04",),  # OOXML = zip
+    ".xlsx": (b"PK\x03\x04",),
+    ".doc": (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",),  # legacy OLE/CFB
+    ".xls": (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",),
+}
+
+
+def _content_matches_ext(ext: str, head: bytes) -> bool:
+    """True if the file header matches the signature expected for the extension.
+
+    Extensions with no registered signature (text formats) always pass.
+    """
+    sigs = _MAGIC_BY_EXT.get(ext)
+    if sigs is None:
+        return True
+    if ext == ".webp":
+        return head[:4] == b"RIFF" and head[8:12] == b"WEBP"
+    return any(head.startswith(sig) for sig in sigs)
+
+
+def validate_file(filename: str, content_type: str, size: int, head: bytes = b"") -> str | None:
+    """Return an error string if the file is invalid, or None if it's acceptable.
+
+    ``head`` is the first bytes of the file; when supplied, the content's magic
+    number must match the extension (declared type/extension alone are
+    attacker-controlled).
+    """
     if size > MAX_SIZE_BYTES:
         mb = size / (1024 * 1024)
         return f"'{filename}' is too large ({mb:.1f} MB). Maximum 10 MB per file."
@@ -89,6 +124,12 @@ def validate_file(filename: str, content_type: str, size: int) -> str | None:
         return (
             f"'{filename}' has an unsupported file type ({declared_type}). "
             "Allowed: PDF, images, text, Word, Excel."
+        )
+
+    if head and not _content_matches_ext(ext, head):
+        return (
+            f"'{filename}' content does not match its '{ext}' type "
+            "(the file may be corrupted or disguised)."
         )
 
     return None
@@ -121,7 +162,7 @@ async def read_upload_files(
 
         name = sanitize_filename(upload.filename)
         content_type = upload.content_type or "application/octet-stream"
-        error = validate_file(name, content_type, len(data))
+        error = validate_file(name, content_type, len(data), head=data[:16])
         if error:
             return [], error
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -210,7 +210,7 @@ async def test_read_too_many_files_returns_error() -> None:
         u = MagicMock()
         u.filename = f"file{i}.pdf"
         u.content_type = "application/pdf"
-        u.read = AsyncMock(return_value=b"X" * 100)
+        u.read = AsyncMock(return_value=b"%PDF-1.4" + b"X" * 92)  # valid magic, 100 bytes
         uploads.append(u)
 
     result, error = await read_upload_files(uploads)
@@ -247,6 +247,72 @@ async def test_read_disallowed_type_returns_error() -> None:
 
     result, error = await read_upload_files([upload])
     assert error is not None
+
+
+# ─── magic-byte content verification (issue #43) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_read_rejects_content_disguised_as_image() -> None:
+    """A .png whose bytes are HTML must be rejected — extension/type alone lie."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.attachment import read_upload_files
+
+    upload = MagicMock()
+    upload.filename = "evidence.png"
+    upload.content_type = "image/png"
+    upload.read = AsyncMock(return_value=b"<html><script>alert(1)</script></html>")
+
+    result, error = await read_upload_files([upload])
+    assert result == []
+    assert error is not None
+    assert "does not match" in error.lower()
+
+
+@pytest.mark.asyncio
+async def test_read_accepts_real_png_magic() -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.attachment import read_upload_files
+
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    upload = MagicMock()
+    upload.filename = "real.png"
+    upload.content_type = "image/png"
+    upload.read = AsyncMock(return_value=png)
+
+    result, error = await read_upload_files([upload])
+    assert error is None
+    assert len(result) == 1
+
+
+@pytest.mark.asyncio
+async def test_read_text_file_needs_no_signature() -> None:
+    """Text formats have no magic number — arbitrary text content is allowed."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.services.attachment import read_upload_files
+
+    upload = MagicMock()
+    upload.filename = "notes.txt"
+    upload.content_type = "text/plain"
+    upload.read = AsyncMock(return_value=b"just some plain notes, no header")
+
+    result, error = await read_upload_files([upload])
+    assert error is None
+    assert len(result) == 1
+
+
+def test_validate_file_magic_mismatch_and_match() -> None:
+    from app.services.attachment import validate_file
+
+    # Header supplied + mismatched → rejected.
+    assert validate_file("x.pdf", "application/pdf", 10, head=b"NOTPDF") is not None
+    # Header supplied + correct magic → accepted.
+    assert validate_file("x.pdf", "application/pdf", 10, head=b"%PDF-1.7") is None
+    # No header (size-only call) → magic check skipped (backward compatible).
+    assert validate_file("x.pdf", "application/pdf", 10) is None
 
 
 # ─── integration tests (require live DB) ──────────────────────────────────────


### PR DESCRIPTION
Closes #43. `validate_file` now checks the file's leading bytes against the extension's signature (PDF, JPEG, PNG, GIF, WebP, DOCX/XLSX, DOC/XLS) so a file can't lie about its type — HTML disguised as `.png` is rejected. Text formats have no signature and are unaffected. Keyed on extension (not the client-declared type); size-only `validate_file` calls stay backward-compatible. Tests: disguised→reject, real magic→accept, text→allowed, mismatch/match unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)