### PR TITLE
fix(security): randomise case-number suffix (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- Case numbers now use a random 5-digit suffix instead of a global sequence, so
+  a new report no longer reveals aggregate cross-tenant report volume. Format is
+  unchanged (`OW-YYYY-NNNNN`) and existing numbers stay valid (#42).
 - Attachment uploads are now verified by magic number: the file's leading bytes
   must match its extension (PDF, JPEG, PNG, GIF, WebP, DOCX/XLSX, DOC/XLS), so a
   file cannot lie about its type (e.g. HTML bytes disguised as a `.png`). Text

--- a/app/services/pin.py
+++ b/app/services/pin.py
@@ -7,32 +7,23 @@ Two-factor design:
 Both are required together to access a report. Neither alone is sufficient.
 """
 
+import secrets
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.report import Report
+def generate_case_number() -> str:
+    """Generate a case number like OW-2026-48210.
 
-
-async def generate_case_number(db: AsyncSession) -> str:
-    """Generate a sequential case number like OW-2026-00042.
-
-    Uses MAX instead of COUNT so hard-deleting a report never causes a
-    subsequent submission to reuse a previously-issued case number.
-
-    Case numbers are globally unique; concurrent submissions can read the same
-    MAX before either commits, so callers must be prepared to retry on the
-    unique-constraint violation (see ``create_report``).
+    The 5-digit component is **random** (not sequential): a sequential number
+    would leak aggregate report volume — in a multi-tenant deployment a new
+    tenant's first report would reveal how many reports exist elsewhere on the
+    instance. The case number is a public, non-secret reference (the PIN is the
+    secret). It is globally unique; a rare random collision is resolved by the
+    caller's retry on the unique-constraint violation (see ``create_report``).
     """
     year = datetime.now(UTC).year
-    result = await db.execute(
-        select(func.max(Report.case_number)).where(Report.case_number.like(f"OW-{year}-%"))
-    )
-    max_case: str | None = result.scalar_one_or_none()
-    sequence = int(max_case.split("-")[2]) + 1 if max_case else 1
-    return f"OW-{year}-{sequence:05d}"
+    return f"OW-{year}-{secrets.randbelow(100000):05d}"
 
 
 def generate_pin() -> str:

--- a/app/services/report.py
+++ b/app/services/report.py
@@ -102,14 +102,13 @@ async def create_report(
     receipt_text = strings.get("system.receipt_message") or fallback.get("system.receipt_message")
     enc_receipt = encrypt_field(report_fernet, receipt_text or "")
 
-    # generate_case_number reads MAX() without a lock, so two concurrent
-    # submissions can compute the same next number. Retry on the resulting
-    # unique-constraint violation instead of surfacing a 500 to the reporter.
+    # generate_case_number returns a random suffix; on the rare collision (or a
+    # concurrent duplicate) retry with a fresh number instead of surfacing a 500.
     last_exc: IntegrityError | None = None
     for _attempt in range(5):
         report = Report(
             id=uuid.uuid4(),
-            case_number=await generate_case_number(db),
+            case_number=generate_case_number(),
             pin_hash=pin_hash,
             org_id=default_org_id,
             category=category,

--- a/tests/test_bug_bounty_v111.py
+++ b/tests/test_bug_bounty_v111.py
@@ -149,7 +149,7 @@ async def test_create_report_retries_on_case_number_collision(
     fresh_number = f"OW-9999-{uuid.uuid4().int % 100000:05d}"
     seq = iter([taken.case_number, fresh_number])
 
-    async def fake_gen(_db):  # noqa: ANN001
+    def fake_gen() -> str:
         return next(seq)
 
     monkeypatch.setattr(report_svc, "generate_case_number", fake_gen)

--- a/tests/test_services_misc.py
+++ b/tests/test_services_misc.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.auth import (
     hash_password,
@@ -185,17 +184,25 @@ def test_generate_pin_unique_each_call() -> None:
     assert len(pins) == 20
 
 
-@pytest.mark.asyncio
-async def test_generate_case_number_sequential(db_session: AsyncSession) -> None:
-    """Two consecutive case numbers in the same year must differ by exactly 1."""
+def test_generate_case_number_format_and_randomness() -> None:
+    """Case numbers keep the OW-YYYY-NNNNN format but the suffix is RANDOM, not
+    sequential — a sequential suffix would leak cross-tenant report volume (#42)."""
+    import re
+    from datetime import UTC, datetime
+
     from app.services.pin import generate_case_number
 
-    first = await generate_case_number(db_session)
-    # We can't easily create a real report in-service here, so just verify format
-    year = __import__("datetime").datetime.now().year
-    assert first.startswith(f"OW-{year}-")
-    seq = int(first.split("-")[2])
-    assert seq >= 1
+    year = datetime.now(UTC).year
+    numbers = [generate_case_number() for _ in range(200)]
+
+    for n in numbers:
+        assert re.fullmatch(rf"OW-{year}-\d{{5}}", n), n
+        assert 0 <= int(n.split("-")[2]) <= 99999
+
+    suffixes = [int(n.split("-")[2]) for n in numbers]
+    # Must not be monotonically increasing (i.e. not a sequence) and should vary.
+    assert suffixes != sorted(suffixes)
+    assert len(set(suffixes)) > 100
 
 
 # ─── services/auth: hash_pin / verify_pin / verify_password ──────────────────


### PR DESCRIPTION
Closes #42. `generate_case_number` used a global `MAX()+1` sequence, leaking aggregate cross-tenant report volume. The suffix is now random (`secrets`). Format unchanged (`OW-YYYY-NNNNN`) → lookups, the admin link-form pattern, and all test regexes still match; existing numbers stay valid. Now a pure sync generator (no DB); `create_report`'s retry loop handles the rare random collision. Tests updated (format+randomness instead of sequential; monkeypatch made sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)