### PR TITLE
chore(release): v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-07-14
+
+Follow-up hardening release resolving the remaining bug-bounty findings (#42–#46).
+
 ### Security
 
+- CSRF protection extended to the two remaining state-changing admin POST
+  endpoints (`/admin/ip-warning/dismiss`, `/admin/demo/reset`). AJAX requests
+  authenticate via an `X-CSRF-Token` header (read from a `<meta>` tag, since the
+  double-submit cookie is HttpOnly) (#44).
 - Case numbers now use a random 5-digit suffix instead of a global sequence, so
   a new report no longer reveals aggregate cross-tenant report volume. Format is
   unchanged (`OW-YYYY-NNNNN`) and existing numbers stay valid (#42).
@@ -23,6 +31,11 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed a dead, unreachable "this account uses Single Sign-On" login branch;
   SSO-only accounts already receive the generic "invalid credentials" error,
   which avoids leaking account existence / auth method (#46).
+
+### Fixed
+
+- Downloading an attachment whose S3 object is missing now returns 404 instead
+  of an unhandled 500; genuine backend errors still surface as 5xx (#45).
 
 ## [1.2.0] — 2026-07-13
 

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "OpenWhistle"
-    app_version: str = "1.2.0"
+    app_version: str = "1.2.1"
 
     # Logging
     log_level: str = "INFO"

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -821,7 +821,7 @@
 
         <h3>Current version</h3>
         <p>
-          <strong>v1.2.0</strong> — Admin System page: installed-version display, opt-in daily GitHub update check, and a build-time file-integrity check. Builds on the v1.1.1 security release (report authorization, privilege-escalation guards, stored-XSS hardening, strict nonce-based CSP). See the
+          <strong>v1.2.1</strong> — Hardening release: magic-byte attachment verification, CSRF on the remaining admin endpoints, reverse-proxy flood protection, randomised case numbers, and an S3 missing-object fix. Builds on v1.2.0 (admin System page) and the v1.1.1 security release. See the
           <a href="https://github.com/openwhistle/OpenWhistle/blob/main/CHANGELOG.md" rel="noopener noreferrer" target="_blank">CHANGELOG</a>
           for a full list of changes.
         </p>

--- a/tests/test_v100.py
+++ b/tests/test_v100.py
@@ -583,7 +583,7 @@ class TestConfigV100Defaults:
     def test_app_version_current(self) -> None:
         from app.config import settings
 
-        assert settings.app_version == "1.2.0"
+        assert settings.app_version == "1.2.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Hardening release resolving the remaining bug-bounty findings **#42–#46**: magic-byte attachment verification (#43), CSRF on the last admin endpoints (#44), nginx per-IP flood protection (#46), randomised case numbers (#42), S3 missing-object 404 (#45). Bumps `app_version` → 1.2.1, finalizes CHANGELOG, updates docs.

After merge: tag `v1.2.1` + GitHub Release (→ multi-registry Docker push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)