### PR TITLE
fix(ui): style demo status pills + drop undefined CSS vars (wave 2)

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -12,7 +12,7 @@
     .lg-oidc-wrap { margin-top: 1.5rem; text-align: center; }
     .lg-or-label { font-size: 0.78rem; color: var(--muted); margin-bottom: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; }
     .lg-ldap-wrap { margin-top: 0.75rem; text-align: center; }
-    .lg-ldap-badge { display: inline-block; font-size: 0.72rem; color: var(--muted); background: var(--surface-2,var(--surface-card)); border: 1px solid var(--hairline); border-radius: 4px; padding: 0.2rem 0.6rem; }
+    .lg-ldap-badge { display: inline-block; font-size: 0.72rem; color: var(--muted); background: var(--surface-card); border: 1px solid var(--hairline); border-radius: 4px; padding: 0.2rem 0.6rem; }
 </style>
 {% endblock %}
 

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -7,12 +7,12 @@
 .st-pin-input { padding-right: 5rem; }
 .st-pin-toggle { position: absolute; right: 0.75rem; top: 50%; transform: translateY(-50%); background: none; border: none; color: var(--muted); font-size: 0.72rem; font-family: var(--font-body); font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; cursor: pointer; padding: 0.2rem 0.3rem; }
 .st-meta-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; font-size: 0.85rem; color: var(--muted); }
-.st-mono-primary { color: var(--text-primary); }
+.st-mono-primary { color: var(--ink); }
 .st-deadlines-section { margin-top: 1.25rem; padding-top: 1rem; border-top: 1px solid var(--hairline); }
 .st-deadlines-title { margin-bottom: 0.6rem; font-size: 0.78rem; letter-spacing: 0.08em; text-transform: uppercase; }
 .st-deadlines-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; font-size: 0.83rem; }
 .st-deadline-label { color: var(--muted); margin-bottom: 0.2rem; }
-.st-success-text { color: var(--success, #2a7a2a); font-weight: 600; }
+.st-success-text { color: var(--success); font-weight: 600; }
 .st-accent-text { color: var(--accent); font-weight: 600; }
 .st-danger-text { color: var(--danger); font-weight: 600; }
 .st-fw600 { font-weight: 600; }
@@ -47,22 +47,22 @@
             <button type="button" class="demo-report-row"
                 data-case="OW-DEMO-00001" data-pin="demo-pin-received-00001">
                 <code class="demo-cred-code">OW-DEMO-00001</code>
-                <span class="demo-report-status status-badge status-received">Received</span>
+                <span class="demo-report-status badge badge-received">Received</span>
             </button>
             <button type="button" class="demo-report-row"
                 data-case="OW-DEMO-00002" data-pin="demo-pin-inreview-00002">
                 <code class="demo-cred-code">OW-DEMO-00002</code>
-                <span class="demo-report-status status-badge status-in_review">In Review</span>
+                <span class="demo-report-status badge badge-in_review">In Review</span>
             </button>
             <button type="button" class="demo-report-row"
                 data-case="OW-DEMO-00003" data-pin="demo-pin-pending-00003">
                 <code class="demo-cred-code">OW-DEMO-00003</code>
-                <span class="demo-report-status status-badge status-pending_feedback">Pending Feedback</span>
+                <span class="demo-report-status badge badge-pending_feedback">Pending Feedback</span>
             </button>
             <button type="button" class="demo-report-row"
                 data-case="OW-DEMO-00004" data-pin="demo-pin-closed-00004">
                 <code class="demo-cred-code">OW-DEMO-00004</code>
-                <span class="demo-report-status status-badge status-closed">Closed</span>
+                <span class="demo-report-status badge badge-closed">Closed</span>
             </button>
         </div>
     </div>


### PR DESCRIPTION
Wave 2 of the Signal rollout — P1 correctness fixes from the DESIGN.md migration fix-list.

## Fixes

- **Unstyled status pills:** the demo-mode report rows on the status page used `.status-badge` / `.status-<status>` classes that are **not defined anywhere** in the CSS, so the pills rendered with no colour. They now reuse the existing, themed `.badge badge-<status>` system (received / in_review / pending_feedback / closed) — no new CSS, and the dead class names are gone.
- **Undefined CSS custom properties:**
  - `status.html` `.st-mono-primary` referenced `--text-primary` (a docs-only token that leaked in, undefined in the app) → `--ink`.
  - `login.html` `.lg-ldap-badge` referenced a phantom `--surface-2` (with a fallback) → `--surface-card`.
  - `status.html` `.st-success-text` had a stale `--success` fallback (`#2a7a2a`) that didn't match the real token → dropped.

No visual change to the real (logged-in) status page — its badges already used `.badge badge-*`.