### PR TITLE
refactor(ui): report.html rpt-1..56 -> semantic classes (wave 7)

### DIFF
--- a/app/templates/admin/report.html
+++ b/app/templates/admin/report.html
@@ -1,69 +1,52 @@
 {% extends "base.html" %}
 
 {% block styles %}<style nonce="{{ request.state.csp_nonce }}">
-.rpt-1 { display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.75rem; }
-.rpt-2 { font-size:0.78rem;color:var(--muted); }
-.rpt-3 { margin-left:auto; }
-.rpt-4 { font-family:var(--font-mono);font-size:clamp(1.1rem,3vw,1.75rem);letter-spacing:0.04em;font-weight:400; }
-.rpt-5 { display:grid;grid-template-columns:2fr 1fr;gap:1.25rem;align-items:start; }
-.rpt-6 { white-space:pre-wrap;font-size:0.95rem;color:var(--body-text);line-height:1.7; }
-.rpt-delay-05 { animation-delay:0.05s; }
-.rpt-7 { margin-bottom:1.5rem; }
-.rpt-8 { color:var(--muted);margin-bottom:1.5rem;font-size:0.88rem; }
-.rpt-delay-08 { animation-delay:0.08s; }
-.rpt-9 { margin-left:0.5rem;font-size:0.7rem;padding:0.15rem 0.5rem;background:var(--warning-subtle);color:var(--warning);border-radius:4px;font-weight:600;letter-spacing:0.05em; }
-.rpt-10 { display:flex;flex-direction:column;gap:0.75rem;margin-bottom:1.25rem; }
-.rpt-11 { padding:0.6rem 0.75rem;background:var(--warning-subtle);border-radius:var(--radius-card); }
-.rpt-12 { font-size:0.75rem;color:var(--muted);margin-bottom:0.25rem; }
-.rpt-13 { color:var(--body-text); }
-.rpt-14 { font-size:0.88rem;white-space:pre-wrap;color:var(--body-text); }
-.rpt-15 { color:var(--muted);margin-bottom:1rem;font-size:0.88rem; }
-.rpt-delay-1 { animation-delay:0.1s; }
-.rpt-16 { list-style:none;padding:0;margin:0 0 1rem;display:flex;flex-direction:column;gap:0.5rem; }
-.rpt-17 { display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0.75rem;background:var(--bg-code);border-radius:6px; }
-.rpt-18 { font-size:0.85rem;font-weight:600; }
-.rpt-19 { font-size:0.7rem; }
-.rpt-20 { font-size:0.8rem;color:var(--muted);flex:1; }
-.rpt-21 { margin:0; }
-.rpt-22 { font-size:0.75rem;padding:0.2rem 0.5rem; }
-.rpt-23 { display:flex;gap:0.5rem;align-items:flex-start; }
-.rpt-24 { flex:1; }
-.rpt-25 { white-space:nowrap; }
-.rpt-delay-12 { animation-delay:0.12s; }
-.rpt-26 { display:flex;flex-direction:column;gap:0.4rem; }
-.rpt-27 { display:flex;gap:0.75rem;align-items:baseline;padding:0.35rem 0;border-bottom:1px solid var(--hairline);font-size:0.8rem; }
-.rpt-28 { color:var(--muted);white-space:nowrap;flex-shrink:0; }
-.rpt-29 { color:var(--body-text);font-weight:600;flex-shrink:0; }
-.rpt-30 { color:var(--accent);font-family:var(--font-mono);font-size:0.75rem; }
-.rpt-31 { color:var(--muted);font-size:0.75rem;font-family:var(--font-mono); }
-.rpt-32 { margin-top:0.75rem; }
-.rpt-33 { font-size:0.78rem; }
-.rpt-34 { color:var(--muted);font-size:0.88rem; }
-.rpt-35 { display:flex;flex-direction:column;gap:1rem;font-size:0.875rem; }
-.rpt-36 { font-size:0.82rem; }
-.rpt-37 { font-size:0.85rem; }
-.rpt-38 { font-size:0.75rem;color:var(--muted);margin-left:0.4rem; }
-.rpt-39 { padding:0.75rem;background:var(--accent-subtle);border:1px solid var(--border-strong);border-radius:var(--radius-sm); }
-.rpt-40 { margin-bottom:0.5rem; }
-.rpt-41 { margin-bottom:0.4rem; }
-.rpt-42 { font-size:0.75rem;color:var(--muted);display:block; }
-.rpt-43 { font-size:0.88rem;font-weight:600; }
-.rpt-44 { font-size:0.88rem; }
-.rpt-45 { margin-top:0.4rem; }
-.rpt-46 { font-size:0.75rem;color:var(--muted); }
-.rpt-47 { font-size:0.8rem;color:var(--muted);font-style:italic; }
-.rpt-delay-04 { animation-delay:0.04s; }
-.rpt-48 { font-size:0.85rem;margin-bottom:1rem; }
-.rpt-delay-06 { animation-delay:0.06s; }
-.rpt-49 { font-size:0.85rem;color:var(--muted); }
-.rpt-delay-1-danger { animation-delay:0.1s;border-color:var(--danger); }
-.rpt-51 { color:var(--danger); }
-.rpt-52 { margin-bottom:1rem; }
-.rpt-53 { font-size:0.75rem;margin-top:0.4rem; }
-.rpt-54 { font-size:0.82rem;color:var(--muted);margin-bottom:0.75rem; }
-.rpt-hidden { display:none; }
-.rpt-55 { display:flex;gap:0.5rem; }
-.rpt-56 { flex:1; }
+/* Header */
+.report-topbar{display:flex;align-items:center;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-3)}
+.report-assignee{font-size:var(--text-hint);color:var(--muted)}
+.report-case-number{font-family:var(--font-mono);font-size:clamp(1.1rem,3vw,1.75rem);letter-spacing:.04em;font-weight:400}
+/* Two-column layout */
+.report-layout{display:grid;grid-template-columns:2fr 1fr;gap:var(--space-5);align-items:start}
+/* Report body + shared text roles */
+.report-description{white-space:pre-wrap;font-size:var(--text-body);color:var(--body-text);line-height:1.7}
+.report-thread{margin-bottom:var(--space-6)}
+.report-empty-note{color:var(--muted);font-size:var(--text-body-sm);margin-bottom:var(--space-4)}
+.report-value-strong{font-size:var(--text-body-sm);font-weight:600}
+/* Internal notes */
+.report-internal-badge{margin-left:var(--space-2);font-size:var(--text-eyebrow);padding:.15rem .5rem;background:var(--warning-subtle);color:var(--warning);border-radius:var(--radius-sm);font-weight:600;letter-spacing:.05em}
+.report-note-list{display:flex;flex-direction:column;gap:var(--space-3);margin-bottom:var(--space-5)}
+.report-note{padding:.6rem .75rem;background:var(--warning-subtle);border-radius:var(--radius-card)}
+.report-note-meta{font-size:var(--text-hint);color:var(--muted);margin-bottom:var(--space-1)}
+.report-note-author{color:var(--body-text)}
+.report-note-body{font-size:var(--text-body-sm);white-space:pre-wrap;color:var(--body-text)}
+/* Linked cases */
+.report-link-list{list-style:none;padding:0;margin:0 0 var(--space-4);display:flex;flex-direction:column;gap:var(--space-2)}
+.report-link-row{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-2) var(--space-3);background:var(--bg-code);border-radius:var(--radius-sm)}
+.report-link-badge{font-size:var(--text-eyebrow)}
+.report-link-category{font-size:var(--text-label);color:var(--muted);flex:1}
+.report-link-add{display:flex;gap:var(--space-2);align-items:flex-start}
+.report-btn-xs{font-size:var(--text-hint);padding:.2rem .5rem}
+/* Audit trail */
+.report-audit-list{display:flex;flex-direction:column;gap:var(--space-1)}
+.report-audit-row{display:flex;gap:var(--space-3);align-items:baseline;padding:.35rem 0;border-bottom:1px solid var(--hairline);font-size:var(--text-label)}
+.report-audit-time{color:var(--muted);white-space:nowrap;flex-shrink:0}
+.report-audit-user{color:var(--body-text);font-weight:600;flex-shrink:0}
+.report-audit-action{color:var(--accent);font-family:var(--font-mono);font-size:var(--text-hint)}
+.report-audit-detail{color:var(--muted);font-size:var(--text-hint);font-family:var(--font-mono)}
+/* Details column */
+.report-detail-list{display:flex;flex-direction:column;gap:var(--space-4);font-size:var(--text-body-sm)}
+.report-detail-value{font-size:var(--text-body-sm)}
+.report-detail-sub{font-size:var(--text-hint);color:var(--muted);margin-left:var(--space-1)}
+.report-confidential{padding:var(--space-3);background:var(--accent-subtle);border:1px solid var(--border-strong);border-radius:var(--radius-sm)}
+.report-confidential-label{font-size:var(--text-hint);color:var(--muted);display:block}
+.report-confidential-value{font-size:var(--text-body-sm);font-weight:600}
+.report-email-note{font-size:var(--text-label);color:var(--muted);font-style:italic}
+/* Action panels */
+.report-action-body{font-size:var(--text-body-sm);margin-bottom:var(--space-4)}
+.report-action-note{font-size:var(--text-label);color:var(--muted);margin-bottom:var(--space-3)}
+.report-delete-header{color:var(--danger)}
+.report-delete-time{font-size:var(--text-hint);margin-top:var(--space-1)}
+.report-danger-panel{border-color:var(--danger)}
 </style>{% endblock %}
 
 {% block title %}{{ t('admin.report.eyebrow') }} {{ report.case_number }} | OpenWhistle{% endblock %}
@@ -85,23 +68,23 @@
 {% block content %}
 <div class="container">
     <div class="page-header">
-        <div class="rpt-1">
+        <div class="report-topbar">
             <a href="/admin/dashboard" class="btn btn-secondary btn-sm">{{ t('admin.back_dashboard') }}</a>
             <span class="badge badge-{{ report.status.value }}">{{ t('status.label.' + report.status.value) }}</span>
             {% if report.assigned_to %}
-            <span class="rpt-2">&#128100; {{ report.assigned_to.username }}</span>
+            <span class="report-assignee">&#128100; {{ report.assigned_to.username }}</span>
             {% endif %}
-            <a href="/admin/reports/{{ report.id }}/export.pdf" class="btn btn-secondary btn-sm rpt-3" download>
+            <a href="/admin/reports/{{ report.id }}/export.pdf" class="btn btn-secondary btn-sm ml-auto" download>
                 &#128196; {{ t('admin.report.export_pdf') }}
             </a>
         </div>
         <div class="page-eyebrow">{{ t('admin.report.eyebrow') }}</div>
-        <h1 class="rpt-4">
+        <h1 class="report-case-number">
             {{ report.case_number }}
         </h1>
     </div>
 
-    <div class="rpt-5">
+    <div class="report-layout">
 
         {# ── Left column: report + thread + reply + notes + links ── #}
         <div>
@@ -113,15 +96,15 @@
                     &nbsp;&nbsp;
                     <span class="badge badge-received">{{ report.category | replace('_', ' ') | title }}</span>
                 </div>
-                <p class="rpt-6">{{ decrypted_description }}</p>
+                <p class="report-description">{{ decrypted_description }}</p>
             </div>
 
             {# Communication thread + reply #}
-            <div class="panel rpt-delay-05">
+            <div class="panel delay-05">
                 <div class="panel-header">{{ t('admin.report.thread') }}</div>
 
                 {% if report.messages %}
-                <div class="thread rpt-7">
+                <div class="thread report-thread">
                     {% for msg in report.messages %}
                     <div class="message message-{{ msg.sender.value }}">
                         <div class="message-meta">
@@ -134,7 +117,7 @@
                     {% endfor %}
                 </div>
                 {% else %}
-                <p class="rpt-8">{{ t('admin.report.no_messages') }}</p>
+                <p class="report-empty-note">{{ t('admin.report.no_messages') }}</p>
                 {% endif %}
 
                 {% if report.status.value != 'closed' %}
@@ -158,26 +141,26 @@
             </div>
 
             {# Internal notes (admin-only) #}
-            <div class="panel rpt-delay-08" id="notes">
+            <div class="panel delay-08" id="notes">
                 <div class="panel-header">
                     {{ t('admin.report.notes.header') }}
-                    <span class="rpt-9">{{ t('admin.report.internal_badge') }}</span>
+                    <span class="report-internal-badge">{{ t('admin.report.internal_badge') }}</span>
                 </div>
 
                 {% if report.notes %}
-                <div class="rpt-10">
+                <div class="report-note-list">
                     {% for note in report.notes %}
-                    <div class="rpt-11">
-                        <div class="rpt-12">
-                            <strong class="rpt-13">{{ note.author_username }}</strong>
+                    <div class="report-note">
+                        <div class="report-note-meta">
+                            <strong class="report-note-author">{{ note.author_username }}</strong>
                             &middot; <span class="mono"><time data-utc="{{ note.created_at.isoformat() }}">{{ note.created_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                         </div>
-                        <div class="rpt-14">{{ note.content }}</div>
+                        <div class="report-note-body">{{ note.content }}</div>
                     </div>
                     {% endfor %}
                 </div>
                 {% else %}
-                <p class="rpt-15">{{ t('admin.report.notes.none') }}</p>
+                <p class="report-empty-note">{{ t('admin.report.notes.none') }}</p>
                 {% endif %}
 
                 <form method="post" action="/admin/reports/{{ report.id }}/notes">
@@ -193,19 +176,19 @@
             </div>
 
             {# Linked cases #}
-            <div class="panel rpt-delay-1" id="links">
+            <div class="panel delay-10" id="links">
                 <div class="panel-header">{{ t('admin.report.links.header') }}</div>
 
                 {% if linked_reports %}
-                <ul class="rpt-16">
+                <ul class="report-link-list">
                     {% for lr in linked_reports %}
-                    <li class="rpt-17">
-                        <a href="/admin/reports/{{ lr.id }}" class="mono rpt-18">{{ lr.case_number }}</a>
-                        <span class="badge badge-{{ lr.status }} rpt-19">{{ t('status.label.' + lr.status) }}</span>
-                        <span class="rpt-20">{{ lr.category | replace('_', ' ') | title }}</span>
-                        <form method="post" action="/admin/reports/{{ report.id }}/links/{{ lr.link_id }}/delete" class="rpt-21" data-confirm="Remove link with {{ lr.case_number }}?">
+                    <li class="report-link-row">
+                        <a href="/admin/reports/{{ lr.id }}" class="mono report-value-strong">{{ lr.case_number }}</a>
+                        <span class="badge badge-{{ lr.status }} report-link-badge">{{ t('status.label.' + lr.status) }}</span>
+                        <span class="report-link-category">{{ lr.category | replace('_', ' ') | title }}</span>
+                        <form method="post" action="/admin/reports/{{ report.id }}/links/{{ lr.link_id }}/delete" class="m-0" data-confirm="Remove link with {{ lr.case_number }}?">
                             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                            <button type="submit" class="btn btn-secondary btn-sm rpt-22">
+                            <button type="submit" class="btn btn-secondary btn-sm report-btn-xs">
                                 {{ t('admin.report.links.remove') }}
                             </button>
                         </form>
@@ -213,40 +196,40 @@
                     {% endfor %}
                 </ul>
                 {% else %}
-                <p class="rpt-15">{{ t('admin.report.links.none') }}</p>
+                <p class="report-empty-note">{{ t('admin.report.links.none') }}</p>
                 {% endif %}
 
-                <form method="post" action="/admin/reports/{{ report.id }}/links" class="rpt-23">
+                <form method="post" action="/admin/reports/{{ report.id }}/links" class="report-link-add">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                    <input type="text" class="form-control rpt-24" name="case_number"
+                    <input type="text" class="form-control flex-1" name="case_number"
                         placeholder="{{ t('admin.report.links.placeholder') }}"
                         pattern="OW-\d{4}-\d{5}" title="Format: OW-YYYY-NNNNN"
                         required>
-                    <button type="submit" class="btn btn-secondary btn-sm rpt-25">{{ t('admin.report.links.button') }}</button>
+                    <button type="submit" class="btn btn-secondary btn-sm whitespace-nowrap">{{ t('admin.report.links.button') }}</button>
                 </form>
             </div>
 
             {# Audit log timeline #}
-            <div class="panel rpt-delay-12" id="audit">
+            <div class="panel delay-12" id="audit">
                 <div class="panel-header">{{ t('admin.report.audit.header') }}</div>
                 {% if audit_entries %}
-                <div class="rpt-26">
+                <div class="report-audit-list">
                     {% for entry in audit_entries %}
-                    <div class="rpt-27">
-                        <span class="mono rpt-28"><time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%m-%d %H:%M') }}</time></span>
-                        <span class="rpt-29">{{ entry.admin_username or 'N/A' }}</span>
-                        <span class="rpt-30">{{ entry.action }}</span>
+                    <div class="report-audit-row">
+                        <span class="mono report-audit-time"><time data-utc="{{ entry.created_at.isoformat() }}">{{ entry.created_at.strftime('%m-%d %H:%M') }}</time></span>
+                        <span class="report-audit-user">{{ entry.admin_username or 'N/A' }}</span>
+                        <span class="report-audit-action">{{ entry.action }}</span>
                         {% if entry.detail %}
-                        <span class="rpt-31">{{ entry.detail[:80] }}</span>
+                        <span class="report-audit-detail">{{ entry.detail[:80] }}</span>
                         {% endif %}
                     </div>
                     {% endfor %}
                 </div>
-                <div class="rpt-32">
-                    <a href="/admin/audit-log?report_id={{ report.id }}" class="btn btn-secondary btn-sm rpt-33">{{ t('admin.report.audit.full_trail') }}</a>
+                <div class="mt-3">
+                    <a href="/admin/audit-log?report_id={{ report.id }}" class="btn btn-secondary btn-sm">{{ t('admin.report.audit.full_trail') }}</a>
                 </div>
                 {% else %}
-                <p class="rpt-34">{{ t('admin.report.audit.none') }}</p>
+                <p class="report-empty-note">{{ t('admin.report.audit.none') }}</p>
                 {% endif %}
             </div>
 
@@ -259,15 +242,15 @@
             <div class="panel">
                 <div class="panel-header">{{ t('admin.report.details') }}</div>
 
-                <div class="rpt-35">
+                <div class="report-detail-list">
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.submitted') }}</div>
-                        <span class="mono rpt-36"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
+                        <span class="mono report-detail-value"><time data-utc="{{ report.submitted_at.isoformat() }}">{{ report.submitted_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></span>
                     </div>
 
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.mode') }}</div>
-                        <span class="rpt-37">
+                        <span class="report-detail-value">
                             {% if report.submission_mode.value == 'confidential' %}
                             <span class="badge badge-in_review">{{ t('submit.step.mode.confidential.label') }}</span>
                             {% else %}
@@ -279,46 +262,46 @@
                     {% if report.location %}
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.location') }}</div>
-                        <span class="rpt-18">{{ report.location.name }}</span>
-                        <span class="mono rpt-38">{{ report.location.code }}</span>
+                        <span class="report-value-strong">{{ report.location.name }}</span>
+                        <span class="mono report-detail-sub">{{ report.location.code }}</span>
                     </div>
                     {% endif %}
 
                     {% if (is_admin or report.assigned_to_id == user.id) and (confidential_name or confidential_contact) %}
-                    <div class="rpt-39">
-                        <div class="detail-label rpt-40">{{ t('admin.report.confidential.header') }}</div>
+                    <div class="report-confidential">
+                        <div class="detail-label mb-2">{{ t('admin.report.confidential.header') }}</div>
                         {% if confidential_name %}
-                        <div class="rpt-41">
-                            <span class="rpt-42">{{ t('admin.report.confidential.name') }}</span>
-                            <span class="rpt-43">{{ confidential_name }}</span>
+                        <div class="mb-2">
+                            <span class="report-confidential-label">{{ t('admin.report.confidential.name') }}</span>
+                            <span class="report-confidential-value">{{ confidential_name }}</span>
                         </div>
                         {% endif %}
                         {% if confidential_contact %}
                         <div>
-                            <span class="rpt-42">{{ t('admin.report.confidential.contact') }}</span>
-                            <span class="rpt-44">{{ confidential_contact }}</span>
+                            <span class="report-confidential-label">{{ t('admin.report.confidential.contact') }}</span>
+                            <span class="report-confidential-value">{{ confidential_contact }}</span>
                         </div>
                         {% endif %}
                         {% if has_secure_email %}
-                        <div class="rpt-45">
-                            <span class="rpt-46">{{ t('admin.report.confidential.secure_email_set') }}</span>
+                        <div class="mt-2">
+                            <span class="report-confidential-label">{{ t('admin.report.confidential.secure_email_set') }}</span>
                         </div>
                         {% endif %}
                     </div>
                     {% elif has_secure_email %}
                     <div>
                         <div class="detail-label">{{ t('admin.report.confidential.secure_email_set') }}</div>
-                        <span class="rpt-47">{{ t('admin.report.confidential.email_note') }}</span>
+                        <span class="report-email-note">{{ t('admin.report.confidential.email_note') }}</span>
                     </div>
                     {% endif %}
 
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.sla7') }}</div>
                         {% if report.acknowledged_at %}
-                            <span class="sla-ok mono rpt-36">&#10003; {{ report.acknowledged_at.strftime('%Y-%m-%d') }}</span>
+                            <span class="sla-ok mono report-detail-value">&#10003; {{ report.acknowledged_at.strftime('%Y-%m-%d') }}</span>
                         {% else %}
                             {% set days = (now - report.submitted_at).days %}
-                            <span class="{{ 'sla-overdue' if days >= 7 else ('sla-warning' if days >= 5 else 'sla-ok') }} mono rpt-36">
+                            <span class="{{ 'sla-overdue' if days >= 7 else ('sla-warning' if days >= 5 else 'sla-ok') }} mono report-detail-value">
                                 {{ t('admin.report.sla.day') }} {{ days }}/7: {{ t('admin.report.sla.not_ack') }}
                             </span>
                         {% endif %}
@@ -328,7 +311,7 @@
                     <div>
                         <div class="detail-label">{{ t('admin.report.detail.sla3m') }}</div>
                         {% set days_left = (report.feedback_due_at - now).days %}
-                        <span class="{{ 'sla-overdue' if days_left < 0 else ('sla-warning' if days_left < 14 else 'sla-ok') }} mono rpt-36">
+                        <span class="{{ 'sla-overdue' if days_left < 0 else ('sla-warning' if days_left < 14 else 'sla-ok') }} mono report-detail-value">
                             {{ report.feedback_due_at.strftime('%Y-%m-%d') }}
                             {% if days_left >= 0 %}({{ days_left }} {{ t('admin.report.sla.days_remaining') }}){% else %}({{ t('admin.report.sla.overdue') }}){% endif %}
                         </span>
@@ -339,7 +322,7 @@
 
             {# Attachments #}
             {% if report.attachments %}
-            <div class="panel rpt-delay-04">
+            <div class="panel delay-04">
                 <div class="panel-header">{{ t('admin.report.attachments.header') }}</div>
                 <ul class="attachment-items">
                     {% for att in report.attachments %}
@@ -358,9 +341,9 @@
 
             {# Acknowledge action #}
             {% if not report.acknowledged_at %}
-            <div class="panel rpt-delay-05">
+            <div class="panel delay-05">
                 <div class="panel-header">{{ t('admin.report.ack.header') }}</div>
-                <p class="rpt-48">{{ t('admin.report.ack.body') }}</p>
+                <p class="report-action-body">{{ t('admin.report.ack.body') }}</p>
                 <form method="post" action="/admin/reports/{{ report.id }}/acknowledge">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                     <button type="submit" class="btn btn-primary btn-block">
@@ -372,7 +355,7 @@
 
             {# Case assignment (admin only) #}
             {% if is_admin %}
-            <div class="panel rpt-delay-06">
+            <div class="panel delay-06">
                 <div class="panel-header">{{ t('admin.report.assign.header') }}</div>
                 <form method="post" action="/admin/reports/{{ report.id }}/assign">
                     <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
@@ -395,7 +378,7 @@
             {% endif %}
 
             {# Status update - only valid transitions #}
-            <div class="panel rpt-delay-08">
+            <div class="panel delay-08">
                 <div class="panel-header">{{ t('admin.report.status.header') }}</div>
                 {% if allowed_transitions %}
                 <form method="post" action="/admin/reports/{{ report.id }}/status" id="status-form">
@@ -414,26 +397,26 @@
                     </button>
                 </form>
                 {% else %}
-                <p class="rpt-49">No further status transitions available.</p>
+                <p class="report-empty-note">No further status transitions available.</p>
                 {% endif %}
             </div>
 
             {# 4-eyes deletion (admin only) #}
             {% if is_admin %}
-            <div class="panel rpt-delay-1-danger">
-                <div class="panel-header rpt-51">{{ t('admin.report.delete.header') }}</div>
+            <div class="panel delay-10 report-danger-panel">
+                <div class="panel-header report-delete-header">{{ t('admin.report.delete.header') }}</div>
 
                 {% if report.deletion_request %}
                     {# Pending deletion request exists #}
-                    <div class="alert alert-error rpt-52">
+                    <div class="alert alert-error">
                         <div class="alert-title">{{ t('admin.report.delete.pending.title') }}</div>
                         {{ t('admin.report.delete.pending.body', username=report.deletion_request.requested_by_username) }}
-                        <div class="mono rpt-53"><time data-utc="{{ report.deletion_request.requested_at.isoformat() }}">{{ report.deletion_request.requested_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></div>
+                        <div class="mono report-delete-time"><time data-utc="{{ report.deletion_request.requested_at.isoformat() }}">{{ report.deletion_request.requested_at.strftime('%Y-%m-%d %H:%M UTC') }}</time></div>
                     </div>
 
                     {% if report.deletion_request.requested_by_id == user.id %}
                     {# Current user requested - can only cancel #}
-                    <p class="rpt-54">{{ t('admin.report.delete.cannot_self') }}</p>
+                    <p class="report-action-note">{{ t('admin.report.delete.cannot_self') }}</p>
                     <form method="post" action="/admin/reports/{{ report.id }}/cancel-delete">
                         <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
                         <button type="submit" class="btn btn-secondary btn-block">{{ t('admin.report.delete.cancel_request') }}</button>
@@ -449,24 +432,24 @@
 
                 {% else %}
                     {# No pending request - show request button #}
-                    <p class="rpt-48">{{ t('admin.report.delete.body') }}</p>
+                    <p class="report-action-body">{{ t('admin.report.delete.body') }}</p>
                     <div id="delete-step-1">
                         <button type="button" id="delete-step-1-btn" class="btn btn-secondary btn-block">
                             {{ t('admin.report.delete.request') }}
                         </button>
                     </div>
-                    <div id="delete-step-2" class="rpt-hidden">
-                        <div class="alert alert-error rpt-52">
+                    <div id="delete-step-2" class="hidden">
+                        <div class="alert alert-error">
                             <div class="alert-title">{{ t('admin.report.delete.confirm.title') }}</div>
                             {{ t('admin.report.delete.confirm.body') }}
                         </div>
                         <form method="post" action="/admin/reports/{{ report.id }}/request-delete">
                             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">
-                            <div class="rpt-55">
-                                <button type="button" id="delete-step-2-cancel-btn" class="btn btn-secondary rpt-56">
+                            <div class="flex gap-2">
+                                <button type="button" id="delete-step-2-cancel-btn" class="btn btn-secondary flex-1">
                                     {{ t('admin.report.delete.cancel') }}
                                 </button>
-                                <button type="submit" class="btn btn-danger rpt-56">
+                                <button type="submit" class="btn btn-danger flex-1">
                                     {{ t('admin.report.delete.request') }}
                                 </button>
                             </div>


### PR DESCRIPTION
Wave 7 — replace `admin/report.html`'s **64 numbered, non-semantic** one-off classes with meaningful semantic ones (DESIGN.md fix-list, the "no quick shot" version).

## What changed

- `rpt-1 … rpt-56` + `rpt-delay-*` + `rpt-hidden` → **~38 semantic classes** (`.report-topbar`, `.report-case-number`, `.report-note`, `.report-audit-row`, `.report-confidential`, `.report-detail-value`, …).
- Built on the **wave-6 scale**: off-scale font sizes (`.78/.82/.85/.88rem`) snap to the `--text-*` type scale; spacing uses `--space-*`.
- Cross-cutting bits use **shared** classes: entrance stagger → `.delay-*`; trivial spacing/flex → existing Tailwind utilities (`ml-auto`, `flex-1`, `mt-3`, `mb-2`, `m-0`, `hidden`, `whitespace-nowrap`, `gap-2`).
- **Dedup:** the two `rpt-52` margins are dropped (`.alert` already has its bottom margin); four muted "empty" notes merge into one `.report-empty-note`; repeated `flex:1` and muted labels unified.

## Verification

- No `rpt-*` remain; every `report-*` used is defined; every `.delay-*` and Tailwind util used resolves in `site.css`.
- Rendered the note / linked-case / audit-row / confidential components on the Signal tokens in **light and dark** — correct.
- Markup structure, JS, and behaviour unchanged. CI (Playwright + axe) covers the page.