### PR TITLE
refactor(ui): consolidate animation-delay one-offs (wave 8)

### DIFF
--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -7,7 +7,6 @@
     .lg-header { margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both; }
     .lg-h1 { font-size: clamp(1.5rem, 4vw, 2.25rem); }
     .lg-subtitle { font-size: 0.88rem; margin-top: 0.5rem; }
-    .lg-panel-anim { animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards; }
     .lg-btn-mt { margin-top: 0.5rem; }
     .lg-oidc-wrap { margin-top: 1.5rem; text-align: center; }
     .lg-or-label { font-size: 0.78rem; color: var(--muted); margin-bottom: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; }
@@ -67,7 +66,7 @@
         <div class="alert alert-error" role="alert">{{ error }}</div>
         {% endif %}
 
-        <div class="panel lg-panel-anim">
+        <div class="panel anim-in delay-08">
             <div class="panel-header">{{ t('login.panel.header') }}</div>
 
             <form method="post" action="/admin/login" novalidate>

--- a/app/templates/login_mfa.html
+++ b/app/templates/login_mfa.html
@@ -7,7 +7,6 @@
     .mfa-header { margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both; }
     .mfa-h1 { font-size: clamp(1.5rem, 4vw, 2.25rem); }
     .mfa-subtitle { font-size: 0.88rem; margin-top: 0.5rem; }
-    .mfa-panel-anim { animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards; }
     .mfa-code-input { font-size: 1.75rem; letter-spacing: 0.4em; text-align: center; padding-bottom: 0.75rem; }
     .mfa-btn-mt { margin-top: 0.5rem; }
     .mfa-back-wrap { margin-top: 1.25rem; text-align: center; }
@@ -37,7 +36,7 @@
         </div>
         {% endif %}
 
-        <div class="panel mfa-panel-anim">
+        <div class="panel anim-in delay-08">
             <div class="panel-header">{{ t('mfa.panel.header') }}</div>
 
             <form method="post" action="/admin/login/mfa" novalidate>

--- a/app/templates/login_mfa_setup.html
+++ b/app/templates/login_mfa_setup.html
@@ -9,8 +9,7 @@
     .mfas-header { margin-bottom: 2rem; animation: fadeSlideIn 0.5s ease both; }
     .mfas-title { font-size: clamp(1.5rem, 4vw, 2.25rem); }
     .mfas-subtitle { font-size: 0.88rem; margin-top: 0.5rem; }
-    .mfas-panel-1 { animation: fadeSlideIn 0.5s 0.08s ease both; opacity: 0; animation-fill-mode: forwards; }
-    .mfas-panel-2 { animation: fadeSlideIn 0.5s 0.18s ease both; opacity: 0; animation-fill-mode: forwards; margin-top: 1.25rem; }
+    .mfas-panel-2 { margin-top: var(--space-5); }
     .mfas-step-body { font-size: 0.88rem; margin-bottom: 1rem; }
     .mfas-qr-wrap { text-align: center; margin: 1.5rem 0; }
     .mfas-qr-img { border: 4px solid var(--border); border-radius: 8px; image-rendering: pixelated; }
@@ -39,7 +38,7 @@
         <div class="alert alert-error" role="alert">{{ error }}</div>
         {% endif %}
 
-        <div class="panel mfas-panel-1">
+        <div class="panel anim-in delay-08">
             <div class="panel-header">{{ t('mfa.setup.step1.header') }}</div>
             <p class="mfas-step-body">{{ t('mfa.setup.step1.body') }}</p>
 
@@ -63,7 +62,7 @@
             </details>
         </div>
 
-        <div class="panel mfas-panel-2">
+        <div class="panel anim-in delay-18 mfas-panel-2">
             <div class="panel-header">{{ t('mfa.setup.step2.header') }}</div>
             <p class="mfas-step-body">{{ t('mfa.setup.step2.body') }}</p>
 

--- a/app/templates/status.html
+++ b/app/templates/status.html
@@ -18,10 +18,6 @@
 .st-fw600 { font-weight: 600; }
 .st-muted-italic { color: var(--muted); font-style: italic; }
 .st-muted-text { color: var(--muted); }
-.st-delay-03 { animation-delay: 0.03s; }
-.st-delay-04 { animation-delay: 0.04s; }
-.st-delay-05 { animation-delay: 0.05s; }
-.st-delay-10 { animation-delay: 0.1s; }
 .st-footer-section { margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--hairline); text-align: center; }
 .st-footer-text { font-size: 0.82rem; color: var(--muted); margin-bottom: 0.75rem; }
 </style>{% endblock %}
@@ -218,7 +214,7 @@
     </div>
 
     {# Progress indicator #}
-    <div class="panel status-progress-panel st-delay-03">
+    <div class="panel status-progress-panel delay-03">
         <div class="panel-header">{{ t('status.progress.title') }}</div>
         <div class="progress-steps">
             {% set steps = ['received', 'in_review', 'pending_feedback', 'closed'] %}
@@ -242,7 +238,7 @@
 
     {# Attachments #}
     {% if report.attachments %}
-    <div class="panel st-delay-04">
+    <div class="panel delay-04">
         <div class="panel-header">{{ t('status.attachments.title') }}</div>
         <ul class="attachment-items">
             {% for att in report.attachments %}
@@ -259,14 +255,14 @@
 
     {# Case closed notice #}
     {% if report.status.value == 'closed' %}
-    <div class="alert alert-info st-delay-04" role="alert">
+    <div class="alert alert-info delay-04" role="alert">
         <div class="alert-title">{{ t('status.closed.title') }}</div>
         {{ t('status.closed.body') }}
     </div>
     {% endif %}
 
     {# Communication thread #}
-    <div class="panel st-delay-05">
+    <div class="panel delay-05">
         <div class="panel-header">{{ t('status.thread.title') }}</div>
 
         {% if report.messages %}
@@ -288,7 +284,7 @@
     </div>
 
     {% if report.status.value != 'closed' %}
-    <div class="panel st-delay-10">
+    <div class="panel delay-10">
         <div class="panel-header">{{ t('status.reply.title') }}</div>
         <form method="post" action="/reply">
             <input type="hidden" name="csrf_token" value="{{ request.state.csrf_token }}">

--- a/app/templates/submit_success.html
+++ b/app/templates/submit_success.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 
 {% block styles %}<style nonce="{{ request.state.csp_nonce }}">
-.ss-fade-in { animation: fadeSlideIn 0.5s ease both; }
-.ss-fade-in-05 { animation: fadeSlideIn 0.5s 0.05s ease both; opacity: 0; animation-fill-mode: forwards; }
-.ss-fade-in-10 { animation: fadeSlideIn 0.5s 0.1s ease both; opacity: 0; animation-fill-mode: forwards; }
 .ss-mt-lg { margin-top: 1.5rem; }
 .ss-confirm-label { display: flex; align-items: flex-start; gap: 0.75rem; margin-top: 1.5rem; padding: 1rem; background: var(--accent-subtle); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); cursor: pointer; }
 .ss-confirm-checkbox { margin-top: 0.15rem; flex-shrink: 0; accent-color: var(--accent); width: 1rem; height: 1rem; }
@@ -16,18 +13,18 @@
 {% block content %}
 <div class="container-sm success-wrapper">
 
-    <div class="success-header ss-fade-in">
+    <div class="success-header anim-in">
         <span class="success-check">✓</span>
         <h1>{{ t('success.title') }}</h1>
         <p>{{ t('success.subtitle') }}</p>
     </div>
 
-    <div class="alert alert-warning ss-fade-in-05" role="alert">
+    <div class="alert alert-warning anim-in delay-05" role="alert">
         <div class="alert-title">{{ t('success.warning.title') }}</div>
         {{ t('success.warning.body') }}
     </div>
 
-    <div class="panel ss-fade-in-10">
+    <div class="panel anim-in delay-10">
         <div class="panel-header">{{ t('success.panel.header') }}</div>
 
         <div class="credential-group">

--- a/app/templates/wizard/setup.html
+++ b/app/templates/wizard/setup.html
@@ -8,7 +8,6 @@
 .setup-manual-text { font-size:0.875rem;text-align:center;color:var(--body-text); }
 .setup-secret-wrap { text-align:center;margin-top:0.5rem; }
 .setup-secret { font-size:0.9rem;user-select:all;word-break:break-all; }
-.setup-panel-delay { animation-delay:0.05s; }
 .setup-totp-input { font-size:1.4rem;letter-spacing:0.3em;text-align:center;padding-bottom:0.6rem; }
 </style>
 {% endblock %}
@@ -54,7 +53,7 @@
         </div>
     </div>
 
-    <div class="panel setup-panel-delay">
+    <div class="panel delay-05">
         <div class="panel-header">{{ t('wizard.step2.header') }}</div>
 
         <form method="post" action="/setup" novalidate>


### PR DESCRIPTION
Wave 8 — final consolidation: replace the scattered per-template entrance-animation classes with the shared `.anim-in` + `.delay-*` utilities from wave 6.

## Changes

- **Pure `animation-delay` helpers → `.delay-*`:** `status.html` (`st-delay-03/04/05/10`), `wizard/setup.html` (`setup-panel-delay`).
- **Full fade-in bundles (animation + `opacity:0` + fill-mode) → `.anim-in` [+ `.delay-*`]:** `submit_success.html` (`ss-fade-in`/`-05`/`-10`), `login.html` (`lg-panel-anim`), `login_mfa.html` (`mfa-panel-anim`), `login_mfa_setup.html` (`mfas-panel-1`/`-2`). The `mfas-panel-2` `margin-top` is kept as a small class on the `--space-5` token.

## Verification

- No residual `st-delay-*` / `ss-fade-in*` / `*-panel-anim` / `setup-panel-delay` in any template.
- The `fadeSlideIn` keyframe ends at `opacity:1` with `forwards` fill, so `.anim-in` elements settle **visible** — confirmed by rendering `anim-in delay-08` and `anim-in delay-18` panels (both fully visible after the animation, correct stagger + margin).
- No behaviour change. CI (Playwright + axe) covers these pages.

This completes the DESIGN.md migration fix-list: the app and docs are on Signal, components are deduped, dead code is gone, and the one-off/numbered classes are consolidated onto a documented token + utility foundation.