### PR TITLE
release: v1.3.0 — Signal design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-07-15
+
+The "Signal" design system — a ground-up visual redesign that unifies the app and
+the public site under one identity, plus a documented design specification.
+
+### Added
+
+- **`DESIGN.md`** — a canonical design system ("Signal") in the google/design.md
+  format: front-matter design tokens (colour, typography, spacing, radii,
+  elevation) and prose covering every component, with first-class light and dark
+  themes.
+- **Design token foundation** in the stylesheet: a `--space-*` spacing scale, a
+  `--text-*` type scale, and shared `.anim-in` / `.delay-*` animation utilities.
+
+### Changed
+
+- **Full "Signal" restyle** of the application — a monochrome warm-neutral ground
+  with a single emerald accent, Sora for display and body text, and JetBrains
+  Mono for case numbers, PINs, timestamps and deadlines. Dark mode is now a warm
+  near-black rather than a cold navy.
+- **Self-hosted fonts reduced to two** (Sora + JetBrains Mono); the Docker image
+  downloads exactly those, replacing the previous three-font set. The default
+  `BRAND_PRIMARY_COLOR` is now emerald (`#0e7c5a`).
+- **Public marketing and documentation pages** (openwhistle.net) converted from
+  their separate serif/gold look onto the same Signal tokens.
+- **Stylesheet and template cleanup**: consolidated duplicated components
+  (`.info-banner` → `.alert`, `.env-table` → `table`, three admin grids →
+  `.admin-split-grid`, inline-form wrappers → `.inline-form`), rebuilt the admin
+  report page's 56 numbered one-off classes into semantic classes on the type
+  scale, and unified the scattered animation-delay helpers.
+
+### Fixed
+
+- The intended body typeface never loaded — its `@font-face` pointed at font
+  files that did not exist, so the app silently fell back to `system-ui`. A real
+  self-hosted font now ships.
+- Dark mode ignored the configured brand colour (the accent was hardcoded); it
+  now derives from `BRAND_PRIMARY_COLOR` in both themes.
+- The public report-status page's status pills were unstyled (they referenced CSS
+  classes that were never defined); they now use the themed badge styles.
+- Removed references to several undefined CSS custom properties.
+
 ## [1.2.1] — 2026-07-14
 
 Follow-up hardening release resolving the remaining bug-bounty findings (#42–#46).

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ zero vendor lock-in, and privacy-first by design.
 - **Custom categories** — DB-driven report categories; full management UI at `/admin/categories`.
 - **PDF export** — Full case export including SLA compliance section (HinSchG §17).
 - **Dashboard statistics** — SLA compliance rate, status distribution, category breakdown.
+- **"Signal" design system** — documented, token-driven identity ([`DESIGN.md`](DESIGN.md)); app + site, light + dark.
 - **Mandatory MFA** — TOTP (compatible with any authenticator app) required for every admin account.
   No exceptions, no bypass.
 - **Object-level authorization** — Every report endpoint enforces per-record access: case managers

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -313,7 +313,30 @@ Critical user journeys to cover:
 
 ---
 
-## v1.3.0 — Privacy Hardening & Attachment Security
+## v1.3.0 — Signal Design System ✓ Released 2026-07-15
+
+> A ground-up visual redesign ("Signal") unifying the app and the public site
+> under one identity, delivered with a documented design specification.
+
+### Design system
+
+- [x] **`DESIGN.md`** — canonical design system in the google/design.md format
+  (front-matter tokens + prose, first-class light and dark)
+- [x] **"Signal" restyle** — monochrome warm-neutral ground, single emerald
+  accent, Sora + JetBrains Mono (self-hosted), warm near-black dark mode
+- [x] **Token foundation** — `--space-*` / `--text-*` scales and shared
+  `.anim-in` / `.delay-*` animation utilities
+- [x] **Public site converted** — `docs/index.html` + `docs/docs.html` folded
+  onto the Signal tokens
+- [x] **Stylesheet + template cleanup** — component de-duplication, the admin
+  report page's numbered one-off classes rebuilt as semantic classes, and the
+  scattered animation-delay helpers unified
+- [x] **Bug fixes** — the intended body font now actually loads; dark mode
+  honours the configured brand colour; the public status pills are styled
+
+---
+
+## v1.4.0 — Privacy Hardening & Attachment Security
 
 > Uploaded files can carry EXIF and document metadata that inadvertently
 > identifies the whistleblower (GPS coordinates, author names, printer serial
@@ -360,7 +383,7 @@ Critical user journeys to cover:
 
 ---
 
-## v1.4.0 — Advanced Case Management
+## v1.5.0 — Advanced Case Management
 
 > Features derived from Hintbox, Formalize/WBS, and whistle.law competitive
 > analysis. These address workflows that compliance officers and case managers
@@ -416,7 +439,7 @@ Critical user journeys to cover:
 
 ---
 
-## v1.5.0 — Multi-Channel Intake & Integration Hooks
+## v1.6.0 — Multi-Channel Intake & Integration Hooks
 
 > Operators increasingly need to receive reports through channels beyond the web
 > form, and connect OpenWhistle to existing compliance tooling (SIEM, GRC
@@ -468,7 +491,7 @@ Critical user journeys to cover:
 
 ---
 
-## v1.6.0 — Compliance Expansion (LkSG, KWG, CSRD)
+## v1.7.0 — Compliance Expansion (LkSG, KWG, CSRD)
 
 > German compliance obligations extend beyond HinSchG. Companies in scope for
 > the Lieferkettengesetz (LkSG, since 2023) require a separate supply-chain

--- a/app/config.py
+++ b/app/config.py
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
 
     # Application
     app_name: str = "OpenWhistle"
-    app_version: str = "1.2.1"
+    app_version: str = "1.3.0"
 
     # Logging
     log_level: str = "INFO"

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -816,7 +816,7 @@
 
         <h3>Current version</h3>
         <p>
-          <strong>v1.2.1</strong> — Hardening release: magic-byte attachment verification, CSRF on the remaining admin endpoints, reverse-proxy flood protection, randomised case numbers, and an S3 missing-object fix. Builds on v1.2.0 (admin System page) and the v1.1.1 security release. See the
+          <strong>v1.3.0</strong> — The "Signal" design system: a ground-up visual redesign unifying the app and this site under one identity (monochrome ground, single emerald accent, self-hosted Sora + JetBrains Mono, first-class light and dark), a documented design specification in <code>DESIGN.md</code>, and a stylesheet/template cleanup. Builds on the v1.2.x hardening releases. See the
           <a href="https://github.com/openwhistle/OpenWhistle/blob/main/CHANGELOG.md" rel="noopener noreferrer" target="_blank">CHANGELOG</a>
           for a full list of changes.
         </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
       "priceCurrency": "EUR"
     },
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
-    "softwareVersion": "1.0.0",
+    "softwareVersion": "1.3.0",
     "keywords": "whistleblower, HinSchG, Hinweisgeberschutz, interne Meldestelle, DSGVO, GDPR, open source, self-hosted, Hinweisgebersystem kostenlos",
     "author": {
       "@type": "Organization",
@@ -1300,7 +1300,7 @@
         </div>
 
         <div class="hero-meta" role="list">
-          <span class="hero-meta-item" role="listitem">Version 1.0.0</span>
+          <span class="hero-meta-item" role="listitem">Version 1.3.0</span>
           <span class="hero-meta-item" role="listitem">GPL-3.0</span>
           <span class="hero-meta-item" role="listitem">Python 3.14</span>
           <span class="hero-meta-item" role="listitem">Docker</span>

--- a/tests/test_v100.py
+++ b/tests/test_v100.py
@@ -583,7 +583,7 @@ class TestConfigV100Defaults:
     def test_app_version_current(self) -> None:
         from app.config import settings
 
-        assert settings.app_version == "1.2.1"
+        assert settings.app_version == "1.3.0"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Cut **v1.3.0**, whose headline is the "Signal" design system shipped across PRs #56–#64.

## Release chores

- `app/config.py`: `app_version` → **1.3.0**; `tests/test_v100.py`: pinned assertion updated.
- **CHANGELOG.md**: `[1.3.0]` entry (Added / Changed / Fixed) covering the DESIGN.md spec + token foundation, the full app restyle, the docs/marketing conversion, the stylesheet/template cleanup, and the font / dark-accent / status-pill fixes.
- **README.md**: design-system feature bullet.
- **Docs version synced** (release-docs checklist): `docs/docs.html` "Current version" → v1.3.0; `docs/index.html` JSON-LD `softwareVersion` and hero meta → 1.3.0 (were stale at 1.0.0).
- **ROADMAP.md**: v1.3.0 recorded as released; the planned Privacy / Case-Management / Multi-Channel / Compliance milestones renumbered to v1.4.0–v1.7.0 (they had reserved v1.3.0).

## Checklist notes

No new env vars, `/admin/*` routes, roles, `ReportStatus` values, or submission-flow steps in this release, so those sections of the admin/whistleblower guides need no change. `BRAND_PRIMARY_COLOR`'s default value changed (→ emerald) and was already synced in docs + compose in the wave-1 PR.

On merge: tag `v1.3.0` + GitHub release → Docker publish workflow pushes images to GHCR / Docker Hub / quay.io.